### PR TITLE
NONE: fix dev pages preview

### DIFF
--- a/www/_app_/docusaurus.config.js
+++ b/www/_app_/docusaurus.config.js
@@ -31,25 +31,18 @@ module.exports = {
           label: "Docs",
           position: "left",
         },
-      ]
+      ],
     },
   },
   presets: [
     [
-      '@docusaurus/preset-classic',
+      "@docusaurus/preset-classic",
       {
         docs: {
           path: "./docs",
           routeBasePath: "docs",
           homePageId: "intro/overview",
           sidebarPath: require.resolve("./sidebars.docs.js"),
-          showLastUpdateTime: true,
-        },
-        dev: {
-          path: "./dev",
-          routeBasePath: "dev",
-          homePageId: "development/overview",
-          sidebarPath: require.resolve("./sidebars.dev.js"),
           showLastUpdateTime: true,
         },
         blog: {
@@ -62,6 +55,17 @@ module.exports = {
     ],
   ],
   plugins: [
+    [
+      require.resolve("@docusaurus/plugin-content-docs"),
+      {
+        path: "./dev",
+        routeBasePath: "dev",
+        homePageId: "development/overview",
+        include: ["**/*.md", "**/*.mdx"],
+        sidebarPath: require.resolve("./sidebars.dev.js"),
+        showLastUpdateTime: true,
+      },
+    ],
     [
       "docusaurus-plugin-auto-sidebars",
       {


### PR DESCRIPTION
## Context

Fix dev page preview, due to the default preset not having the dev parser.

## Changes

This PR introduces the following changes:
* Use `@docusaurus/plugin-content-docs` plugin in `docusaurus.config.js`. 

## Tasks

I've completed the following tasks:
- [x] Signed the Contributers License Agreement (CLA)
- [ ] Added/updated tests
- [ ] Added/updated docs
