### PR TITLE
NONE: add API docs to www-viewer

### DIFF
--- a/www/_app_/pages/docs/api.js
+++ b/www/_app_/pages/docs/api.js
@@ -1,0 +1,36 @@
+import React from "react";
+import Layout from "@theme/Layout";
+import { RedocStandalone } from "redoc";
+
+function About() {
+  return (
+    <Layout title={"Core API"} description="Flagbase Core Swagger Docs.">
+      <RedocStandalone
+        specUrl="/swagger.yaml"
+        options={{
+          theme: {
+            colors: { primary: { main: "#24292E" } },
+            typography: {
+              fontSize: "1em",
+              lineHeight: "1.5em",
+              fontWeightRegular: "400",
+              fontWeightBold: "600",
+              fontWeightLight: "300",
+              fontFamily: "system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif,BlinkMacSystemFont,\"Segoe UI\",Helvetica,Arial,sans-serif,\"Apple Color Emoji\",\"Segoe UI Emoji\",\"Segoe UI Symbol\"",
+            },
+            sidebar: {
+              width: "260px",
+              backgroundColor: "#fafafa",
+              textColor: "#000000",
+              groupItems: {
+                textTransform: "capitalize",
+              },
+            },
+          },
+        }}
+      />
+    </Layout>
+  );
+}
+
+export default About;

--- a/www/docker-compose.yml
+++ b/www/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     ports:
       - 3000:3000
     volumes:
+      - ./_app_/pages/docs:/app/flagbase/src/pages/docs
+      - ../core/api/swagger/swagger.yaml:/app/flagbase/static/swagger.yaml
       - ./_app_/docusaurus.config.js:/app/flagbase/docusaurus.config.js
       - ./blog:/app/flagbase/blog
       - ./dev:/app/flagbase/dev


### PR DESCRIPTION
## Context

Introduced some changes to www viewer to be able to view API docs.

## Changes

This PR introduces the following changes:
* Updated docker-compose file
* Added api docs page (redoc standalone widget)

## Tasks

I've completed the following tasks:
- [x] Signed the Contributers License Agreement (CLA)
- [ ] Added/updated tests
- [ ] Added/updated docs
