### PR TITLE
COM-22: added trait resource

### DIFF
--- a/core/api/swagger/swagger.yaml
+++ b/core/api/swagger/swagger.yaml
@@ -65,6 +65,9 @@ tags:
   - name: targeting-percentages
     x-displayName: Targeting Percentages
     description: Targeting percentages are used when you want to conduct a incremental rollouts on a certain percentage of users. It allows you to rollout variations to explicit percentages of your whole cohort base.
+  - name: traits
+    x-displayName: Trait Management
+    description: Traits represent a particular characteristic of a particular identity (aka users). You can create segments using these traits. Traits can also be used to target variations to specific users.
   - name: segments
     x-displayName: Segment Management
     description: Segments represent a specific group of users based on their attributes. You can define a specific user segments using a set rules. Rules contain conditions that are applied to attributes.
@@ -105,6 +108,7 @@ x-tagGroups:
   - name: Users
     tags:
       - identities
+      - traits
       - segments
       - segment-rules
   - name: Auditing
@@ -312,17 +316,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
       operationId: get-environment
       description: Get a project environment.
-      parameters:
-        - in: query
-          name: workspaceKey
-          description: The workspace key
-          schema:
-            type: string
-        - in: query
-          name: projectKey
-          description: The project key
-          schema:
-            type: string
+      parameters: []
     patch:
       summary: Update environment
       operationId: update-environment
@@ -860,8 +854,6 @@ paths:
       tags:
         - environment-access
       description: Create a new environment access link. Make sure you generate the access key-secret pair with the appropriate permissions type before using this operation.
-      requestBody:
-        $ref: '#/components/requestBodies/AccessInput'
     delete:
       summary: Delete environment access
       operationId: delete-environment-access
@@ -943,7 +935,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Environment'
+              $ref: '#/components/schemas/EnvironmentInput'
         description: Environmnet Object
   '/flags/{workspaceKey}/{projectKey}/{flagKey}':
     parameters:
@@ -1656,6 +1648,170 @@ paths:
             schema:
               $ref: '#/components/schemas/PatchDocument'
         description: Patch Document (RFC 6902)
+  '/traits/{workspaceKey}/{projectKey}/{envKey}/{traitKey}':
+    parameters:
+      - name: projectKey
+        in: path
+        required: true
+        description: The project key
+        schema:
+          type: string
+      - name: envKey
+        in: path
+        required: true
+        description: The environment key
+        schema:
+          type: string
+      - schema:
+          type: string
+        name: workspaceKey
+        in: path
+        required: true
+        description: The workspace key
+      - schema:
+          type: string
+        name: traitKey
+        in: path
+        required: true
+        description: The trait key
+    get:
+      summary: Get trait
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/Trait'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: get-trait
+      description: Get a trait within a specific environment.
+      parameters: []
+      tags:
+        - traits
+    patch:
+      summary: Update trait
+      operationId: update-trait
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/Trait'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      description: Update an existing trait.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchDocument'
+        description: Patch Document (RFC 6902)
+      tags:
+        - traits
+    delete:
+      summary: Delete trait
+      operationId: delete-trait
+      responses:
+        '204':
+          description: No Content
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      description: Delete an existing trait.
+      tags:
+        - traits
+  '/trait/{workspaceKey}/{projectKey}/{environmentKey}':
+    parameters:
+      - name: projectKey
+        in: path
+        required: true
+        description: The project key
+        schema:
+          type: string
+      - schema:
+          type: string
+        name: workspaceKey
+        in: path
+        required: true
+        description: The workspace key
+      - schema:
+          type: string
+        name: environmentKey
+        in: path
+        required: true
+        description: The environment key
+    get:
+      summary: List traits indexed in an environment
+      tags:
+        - traits
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Trait'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: list-traits
+      description: Retreive a list of traits in a particular environment.
+    post:
+      summary: Create trait
+      operationId: create-trait
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/Trait'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      tags:
+        - traits
+      description: Create a new trait for a particular environment
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Trait'
+        description: Environmnet Object
   '/segments/{workspaceKey}/{projectKey}':
     parameters:
       - name: projectKey
@@ -2311,3 +2467,17 @@ components:
           type: string
         access:
           $ref: '#/components/schemas/Access'
+    Trait:
+      title: Trait
+      type: object
+      properties:
+        id:
+          type: string
+        key:
+          type: string
+        isIdentifier:
+          type: boolean
+      required:
+        - id
+        - key
+        - isIdentifier

--- a/core/internal/http/http_endpoints.go
+++ b/core/internal/http/http_endpoints.go
@@ -6,6 +6,7 @@ import (
 	"core/pkg/flag"
 	"core/pkg/ping"
 	"core/pkg/project"
+	"core/pkg/trait"
 	"core/pkg/variation"
 	"core/pkg/workspace"
 
@@ -21,6 +22,7 @@ func ApplyRoutes(r *gin.Engine) {
 	flag.ApplyRoutes(root)
 	ping.ApplyRoutes(root)
 	project.ApplyRoutes(root)
+	trait.ApplyRoutes(root)
 	variation.ApplyRoutes(root)
 	workspace.ApplyRoutes(root)
 }

--- a/core/internal/resource/resource_type.go
+++ b/core/internal/resource/resource_type.go
@@ -24,6 +24,8 @@ const (
 	Segment = "segment"
 	// Identity represents a identity resource
 	Identity = "identity"
+	// Trait represents a certain characteristic of an identity
+	Trait = "trait"
 	// Targeting represents a targeting resource
 	Targeting = "targeting"
 )

--- a/core/migrations/000009_init_identity.up.sql
+++ b/core/migrations/000009_init_identity.up.sql
@@ -1,13 +1,12 @@
 BEGIN;
 
 CREATE DOMAIN identity_resource_key as VARCHAR(50) NOT NULL
-  CHECK (value ~* '^[a-zA-Z0-9]*$');
+  CHECK (value ~* '^[a-zA-Z0-9-]+$');
 
 CREATE TABLE identity (
   id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
   -- attributes
   key identity_resource_key,
-  traits JSONB,
   -- references
   environment_id UUID NOT NULL REFERENCES environment (id),
   -- contraints

--- a/core/migrations/000012_init_trait.down.sql
+++ b/core/migrations/000012_init_trait.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DELETE TABLE trait;
+
+END;

--- a/core/migrations/000012_init_trait.up.sql
+++ b/core/migrations/000012_init_trait.up.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+-- trait keys have to be camel-case
+CREATE DOMAIN trait_resource_key as VARCHAR(50) NOT NULL
+  CHECK (value ~* '([a-z0-9]+|[A-Z0-9]+[a-z0-9]*|[A-Z0-9][a-z0-9]*([A-Z0-9][a-z0-9]*)*)');
+
+CREATE TABLE trait (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  -- attributes
+  key trait_resource_key,
+  is_identifier BOOLEAN DEFAULT FALSE,
+  -- references
+  environment_id UUID NOT NULL REFERENCES environment (id),
+  -- contraints
+  CONSTRAINT trait_key UNIQUE(key, environment_id)
+);
+
+END;

--- a/core/pkg/trait/trait.go
+++ b/core/pkg/trait/trait.go
@@ -1,0 +1,10 @@
+package trait
+
+import rsc "core/internal/resource"
+
+// Trait a key that represents a certain characteristic of an identity.
+type Trait struct {
+	ID           rsc.ID  `json:"id"`
+	Key          rsc.Key `json:"key"`
+	IsIdentifier bool    `json:"isIdentifier"`
+}

--- a/core/pkg/trait/trait_http.go
+++ b/core/pkg/trait/trait_http.go
@@ -1,0 +1,133 @@
+package trait
+
+import (
+	"core/internal/constants"
+	"core/internal/httputils"
+	"core/internal/patch"
+	rsc "core/internal/resource"
+	res "core/internal/response"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ApplyRoutes environment route handlers
+func ApplyRoutes(r *gin.RouterGroup) {
+	routes := r.Group("traits")
+	routes.GET(":workspaceKey/:projectKey/:environmentKey", listHTTPHandler)
+	routes.POST(":workspaceKey/:projectKey/:environmentKey", createHTTPHandler)
+	routes.GET(":workspaceKey/:projectKey/:environmentKey/:traitKey", getHTTPHandler)
+	routes.PATCH(":workspaceKey/:projectKey/:environmentKey/:traitKey", updateHTTPHandler)
+	routes.DELETE(":workspaceKey/:projectKey/:environmentKey/:traitKey", deleteHTTPHandler)
+}
+
+func listHTTPHandler(ctx *gin.Context) {
+	var e res.Errors
+
+	atk, err := httputils.ExtractATK(ctx)
+	if err != nil {
+		e.Append(constants.AuthError, err.Error())
+	}
+
+	workspaceKey := rsc.Key(ctx.Param("workspaceKey"))
+	projectKey := rsc.Key(ctx.Param("projectKey"))
+	environmentKey := rsc.Key(ctx.Param("environmentKey"))
+
+	data, _err := List(atk, workspaceKey, projectKey, environmentKey)
+	if !_err.IsEmpty() {
+		e.Extend(_err)
+	}
+
+	httputils.Send(ctx, 200, data, 500, e)
+}
+
+func createHTTPHandler(ctx *gin.Context) {
+	var e res.Errors
+
+	atk, err := httputils.ExtractATK(ctx)
+	if err != nil {
+		e.Append(constants.AuthError, err.Error())
+	}
+
+	workspaceKey := rsc.Key(ctx.Param("workspaceKey"))
+	projectKey := rsc.Key(ctx.Param("projectKey"))
+	environmentKey := rsc.Key(ctx.Param("environmentKey"))
+
+	var i Trait
+	if err := ctx.BindJSON(&i); err != nil {
+		e.Append(constants.InternalError, err.Error())
+	}
+
+	data, _err := Create(atk, i, workspaceKey, projectKey, environmentKey)
+	if !_err.IsEmpty() {
+		e.Extend(_err)
+	}
+
+	httputils.Send(ctx, 201, data, 500, e)
+}
+
+func getHTTPHandler(ctx *gin.Context) {
+	var e res.Errors
+
+	atk, err := httputils.ExtractATK(ctx)
+	if err != nil {
+		e.Append(constants.AuthError, err.Error())
+	}
+
+	workspaceKey := rsc.Key(ctx.Param("workspaceKey"))
+	projectKey := rsc.Key(ctx.Param("projectKey"))
+	environmentKey := rsc.Key(ctx.Param("environmentKey"))
+	traitKey := rsc.Key(ctx.Param("traitKey"))
+
+	data, _err := Get(atk, workspaceKey, projectKey, environmentKey, traitKey)
+	if !_err.IsEmpty() {
+		e.Extend(_err)
+	}
+
+	httputils.Send(ctx, 200, data, 500, e)
+}
+
+func updateHTTPHandler(ctx *gin.Context) {
+	var e res.Errors
+	var i patch.Patch
+
+	atk, err := httputils.ExtractATK(ctx)
+	if err != nil {
+		e.Append(constants.AuthError, err.Error())
+	}
+
+	workspaceKey := rsc.Key(ctx.Param("workspaceKey"))
+	projectKey := rsc.Key(ctx.Param("projectKey"))
+	environmentKey := rsc.Key(ctx.Param("environmentKey"))
+	traitKey := rsc.Key(ctx.Param("traitKey"))
+
+	if err := ctx.BindJSON(&i); err != nil {
+		e.Append(constants.InternalError, err.Error())
+	}
+
+	data, _err := Update(atk, workspaceKey, projectKey, environmentKey, traitKey, i)
+	if !_err.IsEmpty() {
+		e.Extend(_err)
+	}
+
+	httputils.Send(ctx, 200, data, 500, e)
+}
+
+func deleteHTTPHandler(ctx *gin.Context) {
+	var e res.Errors
+
+	workspaceKey := rsc.Key(ctx.Param("workspaceKey"))
+	projectKey := rsc.Key(ctx.Param("projectKey"))
+	environmentKey := rsc.Key(ctx.Param("environmentKey"))
+	traitKey := rsc.Key(ctx.Param("traitKey"))
+
+	atk, err := httputils.ExtractATK(ctx)
+	if err != nil {
+		e.Append(constants.AuthError, err.Error())
+	}
+
+	if err := Delete(atk, workspaceKey, projectKey, environmentKey, traitKey); !err.IsEmpty() {
+		e.Extend(err)
+	}
+
+	httputils.Send(ctx, 204, &res.Success{}, 500, e)
+}

--- a/core/pkg/trait/trait_service.go
+++ b/core/pkg/trait/trait_service.go
@@ -1,0 +1,277 @@
+package trait
+
+import (
+	"context"
+	"core/internal/constants"
+	"core/internal/db"
+	"core/internal/patch"
+	rsc "core/internal/resource"
+	res "core/internal/response"
+	"core/pkg/auth"
+)
+
+// List returns a list of resource instances
+// (*) atk: access_type <= service
+func List(
+	atk rsc.Token,
+	workspaceKey rsc.Key,
+	projectKey rsc.Key,
+	environmentKey rsc.Key,
+) (*res.Success, *res.Errors) {
+	var o []Trait
+	var e res.Errors
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// authorize operation
+	if err := auth.Authorize(atk, rsc.ServiceAccess); err != nil {
+		e.Append(constants.AuthError, err.Error())
+		cancel()
+	}
+
+	rows, err := db.Pool.Query(ctx, `
+  SELECT
+    t.id, t.key, t.is_identifier
+  FROM
+    workspace w, project p, environment e, trait t
+  WHERE
+    w.key = $1 AND
+    p.key = $2 AND
+    e.key = $3 AND
+    p.workspace_id = w.id AND
+    e.project_id = p.id AND
+    t.environment_key = e.id
+  `, workspaceKey, projectKey, environmentKey)
+	if err != nil {
+		e.Append(constants.NotFoundError, err.Error())
+	}
+
+	for rows.Next() {
+		var _o Trait
+		if err = rows.Scan(
+			&_o.ID,
+			&_o.Key,
+			&_o.IsIdentifier,
+		); err != nil {
+			e.Append(constants.NotFoundError, err.Error())
+		}
+		o = append(o, _o)
+	}
+
+	return &res.Success{Data: o}, &e
+}
+
+// Create creates a new resource instance given the resource instance
+// (*) atk: access_type <= admin
+func Create(
+	atk rsc.Token,
+	i Trait,
+	workspaceKey rsc.Key,
+	projectKey rsc.Key,
+	environmentKey rsc.Key,
+) (*res.Success, *res.Errors) {
+	var o Trait
+	var e res.Errors
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// authorize operation
+	if err := auth.Authorize(atk, rsc.AdminAccess); err != nil {
+		e.Append(constants.AuthError, err.Error())
+		cancel()
+	}
+
+	// create root user
+	row := db.Pool.QueryRow(ctx, `
+  INSERT INTO
+    trait(key, is_identifier, environment_id)
+  VALUES
+    ($1, $2, (
+        SELECT
+          e.id
+        FROM
+          workspace w, project p, environment e
+        WHERE
+          w.key = $3 AND
+          p.key = $4 AND
+          p.key = $5 AND
+          p.workspace_id = w.id AND
+          e.project_id = p.id
+      )
+    )
+  RETURNING
+    id, key, is_identifier;`,
+		i.Key,
+		i.IsIdentifier,
+		workspaceKey,
+		projectKey,
+		environmentKey,
+	)
+	if err := row.Scan(
+		&o.ID,
+		&o.Key,
+		&o.IsIdentifier,
+	); err != nil {
+		e.Append(constants.InputError, err.Error())
+	}
+
+	// Add policy for requesting user, after resource creation
+	if e.IsEmpty() {
+		err := auth.AddPolicy(atk, o.ID, rsc.Trait, rsc.AdminAccess)
+		if err != nil {
+			e.Append(constants.AuthError, err.Error())
+		}
+	}
+
+	return &res.Success{Data: o}, &e
+}
+
+// Get gets a resource instance given an atk & key
+// (*) atk: access_type <= service
+func Get(
+	atk rsc.Token,
+	workspaceKey rsc.Key,
+	projectKey rsc.Key,
+	environmentKey rsc.Key,
+	traitKey rsc.Key,
+) (*res.Success, *res.Errors) {
+	var e res.Errors
+
+	r, err := getResource(
+		workspaceKey,
+		projectKey,
+		environmentKey,
+		traitKey,
+	)
+	if err != nil {
+		e.Append(constants.NotFoundError, err.Error())
+	}
+
+	// authorize operation
+	if err := auth.Enforce(
+		atk,
+		r.ID,
+		rsc.Trait,
+		rsc.ServiceAccess,
+	); err != nil {
+		e.Append(constants.AuthError, err.Error())
+	}
+
+	return &res.Success{Data: r}, &e
+}
+
+// Update updates resource instance given an atk, key & patch object
+// (*) atk: access_type <= user
+func Update(
+	atk rsc.Token,
+	workspaceKey rsc.Key,
+	projectKey rsc.Key,
+	environmentKey rsc.Key,
+	traitKey rsc.Key,
+	patchDoc patch.Patch,
+) (*res.Success, *res.Errors) {
+	var o Trait
+	var e res.Errors
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// get original document
+	r, err := getResource(
+		workspaceKey,
+		projectKey,
+		environmentKey,
+		traitKey,
+	)
+	if err != nil {
+		e.Append(constants.NotFoundError, err.Error())
+		cancel()
+	}
+
+	// authorize operation
+	if err := auth.Enforce(
+		atk,
+		r.ID,
+		rsc.Trait,
+		rsc.UserAccess,
+	); err != nil {
+		e.Append(constants.AuthError, err.Error())
+		cancel()
+	}
+
+	// apply patch and get modified document
+	if err := patch.Transform(r, patchDoc, &o); err != nil {
+		e.Append(constants.InternalError, err.Error())
+		cancel()
+	}
+
+	// update original with patched document
+	if _, err := db.Pool.Exec(ctx, `
+  UPDATE
+    trait
+  SET
+    key = $2, is_identifier = $3
+  WHERE
+    id = $1`,
+		r.ID.String(),
+		o.Key,
+		o.IsIdentifier,
+	); err != nil && err != context.Canceled {
+		e.Append(constants.InternalError, err.Error())
+	}
+
+	return &res.Success{Data: o}, &e
+}
+
+// Delete deletes a resource instance given an atk & key
+// (*) atk: access_type <= admin
+func Delete(
+	atk rsc.Token,
+	workspaceKey rsc.Key,
+	projectKey rsc.Key,
+	environmentKey rsc.Key,
+	traitKey rsc.Key,
+) *res.Errors {
+	var e res.Errors
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// get original document
+	r, err := getResource(
+		workspaceKey,
+		projectKey,
+		environmentKey,
+		traitKey,
+	)
+	if err != nil {
+		e.Append(constants.NotFoundError, err.Error())
+		cancel()
+	}
+
+	// authorize operation
+	if err := auth.Enforce(
+		atk,
+		r.ID,
+		rsc.Trait,
+		rsc.AdminAccess,
+	); err != nil {
+		e.Append(constants.AuthError, err.Error())
+		cancel()
+	}
+
+	if _, err := db.Pool.Exec(ctx, `
+  DELETE FROM
+    trait
+  WHERE
+    id = $1
+  `,
+		r.ID.String(),
+	); err != nil {
+		e.Append(constants.InternalError, err.Error())
+	}
+
+	return &e
+}

--- a/core/pkg/trait/trait_util.go
+++ b/core/pkg/trait/trait_util.go
@@ -1,0 +1,40 @@
+package trait
+
+import (
+	"context"
+	"core/internal/db"
+	rsc "core/internal/resource"
+	"fmt"
+)
+
+func getResource(
+	workspaceKey rsc.Key,
+	projectKey rsc.Key,
+	environmentKey rsc.Key,
+	traitKey rsc.Key,
+) (*Trait, error) {
+	var o Trait
+	row := db.Pool.QueryRow(context.Background(), `
+  SELECT
+    t.id, t.key, t.is_identifier
+  FROM
+    workspace w, project p, environment e, trait t
+  WHERE
+    w.key = $1 AND
+    p.key = $2 AND
+    e.key = $3 AND
+    t.key = $5 AND
+    p.workspace_id = w.id AND
+    e.project_id = p.id AND
+    t.environment_id = e.id
+  `, workspaceKey, projectKey, environmentKey, traitKey)
+	if err := row.Scan(
+		&o.ID,
+		&o.Key,
+		&o.IsIdentifier,
+	); err != nil {
+		return &o, fmt.Errorf("unable to find trait with key %s", environmentKey)
+	}
+
+	return &o, nil
+}


### PR DESCRIPTION
## Context

Added a trait resource, which is essentially a single trait unit that will make up our trait catalog. Traits can be used when creating segments or custom flag targeting rules.  

## Changes

This PR introduces the following changes:
* Added resource
* Added http handlers
* Added resource utils
* Updated swagger file

## Tasks

I've completed the following tasks:
- [x] Signed the Contributers License Agreement (CLA)
- [ ] Added/updated tests
- [ ] Added/updated docs
