### PR TITLE
OSS-68: added CI via github actions for UI

### DIFF
--- a/.github/workflows/ci-flagbase-ui.yml
+++ b/.github/workflows/ci-flagbase-ui.yml
@@ -1,0 +1,29 @@
+name: ci-flagbase-ui
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'ui/**'
+
+jobs:
+  build:
+    name: Build, Test and Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@master
+
+      - name: Install dependencies
+        uses: actions/setup-node@master
+        with:
+          node-version: 12
+      - run: npm ci
+        working-directory: ./ui
+
+      - name: Build app
+        run: npm run build
+        run: npm run test
+        run: npm run lint
+        working-directory: ./ui


### PR DESCRIPTION
## Context

Added CI for UI that builds, tests & ensures linting

## Changes

This PR introduces the following changes:
* Added `.github/workflows/ci-flagbase-ui.yml`

## Tasks

I've completed the following tasks:
- [x] Signed the Contributers License Agreement (CLA)
- [ ] Added/updated tests
- [ ] Added/updated docs
