### PR TITLE
REFACTOR: http handler -> api handler

### DIFF
--- a/core/internal/app/access/access_api.go
+++ b/core/internal/app/access/access_api.go
@@ -10,10 +10,10 @@ import (
 // ApplyRoutes access route handlers
 func ApplyRoutes(r *gin.RouterGroup) {
 	routes := r.Group(rsc.RouteAccess)
-	routes.POST("/token", generateTokenHTTPHandler)
+	routes.POST("/token", generateTokenAPIHandler)
 }
 
-func generateTokenHTTPHandler(ctx *gin.Context) {
+func generateTokenAPIHandler(ctx *gin.Context) {
 	var i KeySecretPair
 	if err := ctx.BindJSON(&i); err != nil {
 		return

--- a/core/internal/app/environment/environment_api.go
+++ b/core/internal/app/environment/environment_api.go
@@ -23,14 +23,14 @@ func ApplyRoutes(r *gin.RouterGroup) {
 		rsc.EnvironmentKey,
 	)
 
-	routes.GET(rootPath, listHTTPHandler)
-	routes.POST(rootPath, createHTTPHandler)
-	routes.GET(resourcePath, getHTTPHandler)
-	routes.PATCH(resourcePath, updateHTTPHandler)
-	routes.DELETE(resourcePath, deleteHTTPHandler)
+	routes.GET(rootPath, listAPIHandler)
+	routes.POST(rootPath, createAPIHandler)
+	routes.GET(resourcePath, getAPIHandler)
+	routes.PATCH(resourcePath, updateAPIHandler)
+	routes.DELETE(resourcePath, deleteAPIHandler)
 }
 
-func listHTTPHandler(ctx *gin.Context) {
+func listAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -56,7 +56,7 @@ func listHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func createHTTPHandler(ctx *gin.Context) {
+func createAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -88,7 +88,7 @@ func createHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func getHTTPHandler(ctx *gin.Context) {
+func getAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -115,7 +115,7 @@ func getHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func updateHTTPHandler(ctx *gin.Context) {
+func updateAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 	var i patch.Patch
 
@@ -148,7 +148,7 @@ func updateHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func deleteHTTPHandler(ctx *gin.Context) {
+func deleteAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)

--- a/core/internal/app/flag/flag_api.go
+++ b/core/internal/app/flag/flag_api.go
@@ -23,14 +23,14 @@ func ApplyRoutes(r *gin.RouterGroup) {
 		rsc.FlagKey,
 	)
 
-	routes.GET(rootPath, listHTTPHandler)
-	routes.POST(rootPath, createHTTPHandler)
-	routes.GET(resourcePath, getHTTPHandler)
-	routes.PATCH(resourcePath, updateHTTPHandler)
-	routes.DELETE(resourcePath, deleteHTTPHandler)
+	routes.GET(rootPath, listAPIHandler)
+	routes.POST(rootPath, createAPIHandler)
+	routes.GET(resourcePath, getAPIHandler)
+	routes.PATCH(resourcePath, updateAPIHandler)
+	routes.DELETE(resourcePath, deleteAPIHandler)
 }
 
-func listHTTPHandler(ctx *gin.Context) {
+func listAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -56,7 +56,7 @@ func listHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func createHTTPHandler(ctx *gin.Context) {
+func createAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -88,7 +88,7 @@ func createHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func getHTTPHandler(ctx *gin.Context) {
+func getAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -115,7 +115,7 @@ func getHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func updateHTTPHandler(ctx *gin.Context) {
+func updateAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 	var i patch.Patch
 
@@ -148,7 +148,7 @@ func updateHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func deleteHTTPHandler(ctx *gin.Context) {
+func deleteAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)

--- a/core/internal/app/healthcheck/healthcheck_api.go
+++ b/core/internal/app/healthcheck/healthcheck_api.go
@@ -8,10 +8,10 @@ import (
 
 // ApplyRoutes healthcheck route handler
 func ApplyRoutes(r *gin.RouterGroup) {
-	r.GET("healthcheck", healthCheckHTTPHandler)
+	r.GET("healthcheck", healthCheckAPIHandler)
 }
 
-func healthCheckHTTPHandler(ctx *gin.Context) {
+func healthCheckAPIHandler(ctx *gin.Context) {
 	pong, err := HealthCheck(ctx)
 	if err != nil {
 		ctx.AbortWithStatus(http.StatusInternalServerError)

--- a/core/internal/app/identity/identity_api.go
+++ b/core/internal/app/identity/identity_api.go
@@ -23,12 +23,12 @@ func ApplyRoutes(r *gin.RouterGroup) {
 		rsc.IdentityKey,
 	)
 
-	routes.GET(rootPath, listHTTPHandler)
-	routes.GET(resourcePath, getHTTPHandler)
-	routes.DELETE(resourcePath, deleteHTTPHandler)
+	routes.GET(rootPath, listAPIHandler)
+	routes.GET(resourcePath, getAPIHandler)
+	routes.DELETE(resourcePath, deleteAPIHandler)
 }
 
-func listHTTPHandler(ctx *gin.Context) {
+func listAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -55,7 +55,7 @@ func listHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func getHTTPHandler(ctx *gin.Context) {
+func getAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -83,7 +83,7 @@ func getHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func deleteHTTPHandler(ctx *gin.Context) {
+func deleteAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)

--- a/core/internal/app/project/project_api.go
+++ b/core/internal/app/project/project_api.go
@@ -22,14 +22,14 @@ func ApplyRoutes(r *gin.RouterGroup) {
 		rsc.ProjectKey,
 	)
 
-	routes.GET(rootPath, listHTTPHandler)
-	routes.POST(rootPath, createHTTPHandler)
-	routes.GET(resourcePath, getHTTPHandler)
-	routes.PATCH(resourcePath, updateHTTPHandler)
-	routes.DELETE(resourcePath, deleteHTTPHandler)
+	routes.GET(rootPath, listAPIHandler)
+	routes.POST(rootPath, createAPIHandler)
+	routes.GET(resourcePath, getAPIHandler)
+	routes.PATCH(resourcePath, updateAPIHandler)
+	routes.DELETE(resourcePath, deleteAPIHandler)
 }
 
-func listHTTPHandler(ctx *gin.Context) {
+func listAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -54,7 +54,7 @@ func listHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func createHTTPHandler(ctx *gin.Context) {
+func createAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -85,7 +85,7 @@ func createHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func getHTTPHandler(ctx *gin.Context) {
+func getAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -111,7 +111,7 @@ func getHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func updateHTTPHandler(ctx *gin.Context) {
+func updateAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 	var i patch.Patch
 
@@ -143,7 +143,7 @@ func updateHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func deleteHTTPHandler(ctx *gin.Context) {
+func deleteAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)

--- a/core/internal/app/segment/segment_api.go
+++ b/core/internal/app/segment/segment_api.go
@@ -23,14 +23,14 @@ func ApplyRoutes(r *gin.RouterGroup) {
 		rsc.SegmentKey,
 	)
 
-	routes.GET(rootPath, listHTTPHandler)
-	routes.POST(rootPath, createHTTPHandler)
-	routes.GET(resourcePath, getHTTPHandler)
-	routes.PATCH(resourcePath, updateHTTPHandler)
-	routes.DELETE(resourcePath, deleteHTTPHandler)
+	routes.GET(rootPath, listAPIHandler)
+	routes.POST(rootPath, createAPIHandler)
+	routes.GET(resourcePath, getAPIHandler)
+	routes.PATCH(resourcePath, updateAPIHandler)
+	routes.DELETE(resourcePath, deleteAPIHandler)
 }
 
-func listHTTPHandler(ctx *gin.Context) {
+func listAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -56,7 +56,7 @@ func listHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func createHTTPHandler(ctx *gin.Context) {
+func createAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -88,7 +88,7 @@ func createHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func getHTTPHandler(ctx *gin.Context) {
+func getAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -115,7 +115,7 @@ func getHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func updateHTTPHandler(ctx *gin.Context) {
+func updateAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 	var i patch.Patch
 
@@ -148,7 +148,7 @@ func updateHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func deleteHTTPHandler(ctx *gin.Context) {
+func deleteAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)

--- a/core/internal/app/segmentrule/segmentrule_api.go
+++ b/core/internal/app/segmentrule/segmentrule_api.go
@@ -24,14 +24,14 @@ func ApplyRoutes(r *gin.RouterGroup) {
 		rsc.RuleKey,
 	)
 
-	routes.GET(rootPath, listHTTPHandler)
-	routes.POST(rootPath, createHTTPHandler)
-	routes.GET(resourcePath, getHTTPHandler)
-	routes.PATCH(resourcePath, updateHTTPHandler)
-	routes.DELETE(resourcePath, deleteHTTPHandler)
+	routes.GET(rootPath, listAPIHandler)
+	routes.POST(rootPath, createAPIHandler)
+	routes.GET(resourcePath, getAPIHandler)
+	routes.PATCH(resourcePath, updateAPIHandler)
+	routes.DELETE(resourcePath, deleteAPIHandler)
 }
 
-func listHTTPHandler(ctx *gin.Context) {
+func listAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -58,7 +58,7 @@ func listHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func createHTTPHandler(ctx *gin.Context) {
+func createAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -91,7 +91,7 @@ func createHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func getHTTPHandler(ctx *gin.Context) {
+func getAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -119,7 +119,7 @@ func getHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func updateHTTPHandler(ctx *gin.Context) {
+func updateAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 	var i patch.Patch
 
@@ -153,7 +153,7 @@ func updateHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func deleteHTTPHandler(ctx *gin.Context) {
+func deleteAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)

--- a/core/internal/app/trait/trait_api.go
+++ b/core/internal/app/trait/trait_api.go
@@ -24,14 +24,14 @@ func ApplyRoutes(r *gin.RouterGroup) {
 		rsc.TraitKey,
 	)
 
-	routes.GET(rootPath, listHTTPHandler)
-	routes.POST(rootPath, createHTTPHandler)
-	routes.GET(resourcePath, getHTTPHandler)
-	routes.PATCH(resourcePath, updateHTTPHandler)
-	routes.DELETE(resourcePath, deleteHTTPHandler)
+	routes.GET(rootPath, listAPIHandler)
+	routes.POST(rootPath, createAPIHandler)
+	routes.GET(resourcePath, getAPIHandler)
+	routes.PATCH(resourcePath, updateAPIHandler)
+	routes.DELETE(resourcePath, deleteAPIHandler)
 }
 
-func listHTTPHandler(ctx *gin.Context) {
+func listAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -58,7 +58,7 @@ func listHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func createHTTPHandler(ctx *gin.Context) {
+func createAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -91,7 +91,7 @@ func createHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func getHTTPHandler(ctx *gin.Context) {
+func getAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -119,7 +119,7 @@ func getHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func updateHTTPHandler(ctx *gin.Context) {
+func updateAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 	var i patch.Patch
 
@@ -153,7 +153,7 @@ func updateHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func deleteHTTPHandler(ctx *gin.Context) {
+func deleteAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)

--- a/core/internal/app/variation/variation_api.go
+++ b/core/internal/app/variation/variation_api.go
@@ -24,14 +24,14 @@ func ApplyRoutes(r *gin.RouterGroup) {
 		rsc.VariationKey,
 	)
 
-	routes.GET(rootPath, listHTTPHandler)
-	routes.POST(rootPath, createHTTPHandler)
-	routes.GET(resourcePath, getHTTPHandler)
-	routes.PATCH(resourcePath, updateHTTPHandler)
-	routes.DELETE(resourcePath, deleteHTTPHandler)
+	routes.GET(rootPath, listAPIHandler)
+	routes.POST(rootPath, createAPIHandler)
+	routes.GET(resourcePath, getAPIHandler)
+	routes.PATCH(resourcePath, updateAPIHandler)
+	routes.DELETE(resourcePath, deleteAPIHandler)
 }
 
-func listHTTPHandler(ctx *gin.Context) {
+func listAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -58,7 +58,7 @@ func listHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func createHTTPHandler(ctx *gin.Context) {
+func createAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -91,7 +91,7 @@ func createHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func getHTTPHandler(ctx *gin.Context) {
+func getAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -119,7 +119,7 @@ func getHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func updateHTTPHandler(ctx *gin.Context) {
+func updateAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 	var i patch.Patch
 
@@ -153,7 +153,7 @@ func updateHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func deleteHTTPHandler(ctx *gin.Context) {
+func deleteAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)

--- a/core/internal/app/workspace/workspace_api.go
+++ b/core/internal/app/workspace/workspace_api.go
@@ -18,14 +18,14 @@ func ApplyRoutes(r *gin.RouterGroup) {
 		rsc.WorkspaceKey,
 	)
 
-	routes.GET("", listHTTPHandler)
-	routes.POST("", createHTTPHandler)
-	routes.GET(resourcePath, getHTTPHandler)
-	routes.PATCH(resourcePath, updateHTTPHandler)
-	routes.DELETE(resourcePath, deleteHTTPHandler)
+	routes.GET("", listAPIHandler)
+	routes.POST("", createAPIHandler)
+	routes.GET(resourcePath, getAPIHandler)
+	routes.PATCH(resourcePath, updateAPIHandler)
+	routes.DELETE(resourcePath, deleteAPIHandler)
 }
 
-func listHTTPHandler(ctx *gin.Context) {
+func listAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -47,7 +47,7 @@ func listHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func createHTTPHandler(ctx *gin.Context) {
+func createAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -74,7 +74,7 @@ func createHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func getHTTPHandler(ctx *gin.Context) {
+func getAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)
@@ -99,7 +99,7 @@ func getHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func updateHTTPHandler(ctx *gin.Context) {
+func updateAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 	var i patch.Patch
 
@@ -130,7 +130,7 @@ func updateHTTPHandler(ctx *gin.Context) {
 	)
 }
 
-func deleteHTTPHandler(ctx *gin.Context) {
+func deleteAPIHandler(ctx *gin.Context) {
 	var e res.Errors
 
 	atk, err := httputils.ExtractATK(ctx)


### PR DESCRIPTION
## Context

We want to distinguish between different worker modes (api, streamer). In order to make the worker-mode specific code easier to find, we'll use consistent terminology. 

## Changes

This PR introduces the following changes:
* Rename *HTTPHandler -> *APIHandler

## Tasks

I've completed the following tasks:
- [x] Signed the Contributers License Agreement (CLA)
- [ ] Added/updated tests
- [ ] Added/updated docs
