### PR TITLE
OSS-65: access to use server context

### DIFF
--- a/core/cmd/manage/manage_access.go
+++ b/core/cmd/manage/manage_access.go
@@ -5,10 +5,8 @@ import (
 	"core/internal/app/access"
 	"core/internal/pkg/cmdutil"
 	cons "core/internal/pkg/constants"
-	"core/internal/pkg/policy"
 	rsc "core/internal/pkg/resource"
-	"core/pkg/db"
-	"errors"
+	srv "core/internal/pkg/server"
 	"runtime"
 
 	"github.com/sirupsen/logrus"
@@ -66,53 +64,31 @@ var ManageAccessCreateCommand cli.Command = cli.Command{
 		},
 	}, cmdutil.GlobalFlags...),
 	Action: func(ctx *cli.Context) error {
-		cfg := AccessConfig{
-			PGConnStr: ctx.String(cmdutil.PGConnStrFlag),
-			Verbose:   ctx.Bool(cmdutil.VerboseFlag),
+		sctx, err := srv.Setup(srv.Config{
+			Ctx:           context.Background(),
+			PGConnStr:     ctx.String(cmdutil.PGConnStrFlag),
+			RedisAddr:     ctx.String(cmdutil.RedisAddr),
+			RedisPassword: ctx.String(cmdutil.RedisPassword),
+			RedisDB:       int(ctx.Uint(cmdutil.RedisDB)),
+			Verbose:       ctx.Bool(cmdutil.VerboseFlag),
+		})
+		if err != nil {
+			logrus.Error("Unable to setup app context. Reason: ", err.Error())
+			runtime.Goexit()
+		}
+		defer srv.Cleanup(sctx)
+
+		if _, err := access.Create(sctx, access.Access{
 			Key:       rsc.Key(ctx.String(KeyFlag)),
 			Secret:    ctx.String(SecretFlag),
 			Type:      ctx.String(TypeFlag),
+			Tags:      []string{},
+			ExpiresAt: cons.MaxUnixTime,
+		}); err.IsEmpty() {
+			// TODO: add error reasons
+			sctx.Log.Error.Msg("Unable to create access")
 		}
-		CreateAccess(cfg)
+
 		return nil
 	},
-}
-
-// CreateAccess create access
-func CreateAccess(cfg AccessConfig) {
-	if err := db.NewPool(context.Background(), cfg.PGConnStr, cfg.Verbose); err != nil {
-		logrus.Error("Unable to connect to db - ", err.Error())
-		runtime.Goexit()
-	}
-	defer db.Pool.Close()
-
-	if err := policy.NewEnforcer(cfg.PGConnStr); err != nil {
-		logrus.Error("Unable to start enforcer - ", err.Error())
-		runtime.Goexit()
-	}
-
-	if err := createAccess(cfg.Key, cfg.Secret, cfg.Type); err != nil {
-		logrus.Error("Unable to create root access. Perhap the access-key already exists.")
-		runtime.Goexit()
-	} else {
-		logrus.WithFields(logrus.Fields{
-			"key":    cfg.Key,
-			"secret": cfg.Secret,
-		}).Info("Created access")
-	}
-}
-
-func createAccess(accessKey rsc.Key, accessSecret string, accessType string) error {
-	_, err := access.Create(access.Access{
-		Key:       accessKey,
-		Secret:    accessSecret,
-		Type:      accessType,
-		Tags:      []string{},
-		ExpiresAt: cons.MaxUnixTime,
-	})
-	if err.Errors != nil {
-		return errors.New("unable to create access - perhaps this resource already exists")
-	}
-
-	return nil
 }

--- a/core/cmd/service/service_api.go
+++ b/core/cmd/service/service_api.go
@@ -8,7 +8,7 @@ import (
 
 	"core/internal/pkg/api"
 	"core/internal/pkg/policy"
-	"core/internal/pkg/server"
+	srv "core/internal/pkg/server"
 	"core/pkg/db"
 
 	"github.com/sirupsen/logrus"
@@ -49,7 +49,7 @@ func StartAPI(cfg APIConfig) {
 		runtime.Goexit()
 	}
 
-	sctx, err := server.Setup(server.Config{
+	sctx, err := srv.Setup(srv.Config{
 		Ctx:           context.Background(),
 		PGConnStr:     cfg.PGConnStr,
 		RedisAddr:     cfg.RedisAddr,

--- a/core/cmd/service/service_api.go
+++ b/core/cmd/service/service_api.go
@@ -61,6 +61,7 @@ func StartAPI(cfg APIConfig) {
 		logrus.Error("Unable to setup app context. Reason: ", err.Error())
 		runtime.Goexit()
 	}
+	defer srv.Cleanup(sctx)
 
 	api.New(sctx, api.Config{
 		Host:    cfg.Host,

--- a/core/cmd/service/service_api.go
+++ b/core/cmd/service/service_api.go
@@ -2,16 +2,12 @@ package service
 
 import (
 	"context"
-	"io/ioutil"
-	"log"
 	"runtime"
 
 	"core/internal/pkg/api"
 	"core/internal/pkg/policy"
 	srv "core/internal/pkg/server"
 	"core/pkg/db"
-
-	"github.com/sirupsen/logrus"
 )
 
 // APIConfig API service configuration
@@ -26,42 +22,31 @@ type APIConfig struct {
 }
 
 // StartAPI start API
-func StartAPI(cfg APIConfig) {
-	if !cfg.Verbose {
-		log.SetOutput(ioutil.Discard)
-		logrus.SetOutput(ioutil.Discard)
-	}
+func StartAPI(sctx *srv.Ctx, cfg APIConfig) {
+	sctx.Log.Info.Str(
+		"host", cfg.Host,
+	).Bool(
+		"verbose", cfg.Verbose,
+	).Int(
+		"apiPort", cfg.APIPort,
+	).Msg("Starting API")
 
-	logrus.WithFields(logrus.Fields{
-		"host":    cfg.Host,
-		"apiPort": cfg.APIPort,
-		"verbose": cfg.Verbose,
-	}).Info("Starting API")
-
+	// TODO remove global db connection
 	if err := db.NewPool(context.Background(), cfg.PGConnStr, cfg.Verbose); err != nil {
-		logrus.Error("Unable to connect to db - ", err.Error())
+		sctx.Log.Error.Str(
+			"reason", err.Error(),
+		).Msg("Unable to connect to db")
 		runtime.Goexit()
 	}
 	defer db.Pool.Close()
 
+	// TODO remove global policy
 	if err := policy.NewEnforcer(cfg.PGConnStr); err != nil {
-		logrus.Error("Unable to start enforcer - ", err.Error())
+		sctx.Log.Error.Str(
+			"reason", err.Error(),
+		).Msg("Unable to start enforcer")
 		runtime.Goexit()
 	}
-
-	sctx, err := srv.Setup(srv.Config{
-		Ctx:           context.Background(),
-		PGConnStr:     cfg.PGConnStr,
-		RedisAddr:     cfg.RedisAddr,
-		RedisPassword: cfg.RedisPassword,
-		RedisDB:       cfg.RedisDB,
-		Verbose:       cfg.Verbose,
-	})
-	if err != nil {
-		logrus.Error("Unable to setup app context. Reason: ", err.Error())
-		runtime.Goexit()
-	}
-	defer srv.Cleanup(sctx)
 
 	api.New(sctx, api.Config{
 		Host:    cfg.Host,

--- a/core/internal/app/access/access_api.go
+++ b/core/internal/app/access/access_api.go
@@ -2,24 +2,25 @@ package access
 
 import (
 	rsc "core/internal/pkg/resource"
+	srv "core/internal/pkg/server"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 )
 
 // ApplyRoutes access route handlers
-func ApplyRoutes(r *gin.RouterGroup) {
+func ApplyRoutes(sctx *srv.Ctx, r *gin.RouterGroup) {
 	routes := r.Group(rsc.RouteAccess)
-	routes.POST("/token", generateTokenAPIHandler)
+	routes.POST("/token", func(gctx *gin.Context) { generateTokenAPIHandler(sctx, gctx) })
 }
 
-func generateTokenAPIHandler(ctx *gin.Context) {
+func generateTokenAPIHandler(sctx *srv.Ctx, ctx *gin.Context) {
 	var i KeySecretPair
 	if err := ctx.BindJSON(&i); err != nil {
 		return
 	}
 
-	data, err := GenerateToken(i)
+	data, err := GenerateToken(sctx, i)
 	if err.Errors != nil {
 		ctx.AbortWithStatusJSON(http.StatusOK, err)
 		return

--- a/core/internal/app/access/access_service.go
+++ b/core/internal/app/access/access_service.go
@@ -3,8 +3,8 @@ package access
 import (
 	"context"
 	cons "core/internal/pkg/constants"
+	srv "core/internal/pkg/server"
 	"core/pkg/crypto"
-	"core/pkg/db"
 	"core/pkg/jwt"
 	res "core/pkg/response"
 	"encoding/json"
@@ -13,7 +13,7 @@ import (
 )
 
 // GenerateToken generate an access token via an access pair
-func GenerateToken(i KeySecretPair) (
+func GenerateToken(sctx *srv.Ctx, i KeySecretPair) (
 	*res.Success,
 	*res.Errors,
 ) {
@@ -21,7 +21,7 @@ func GenerateToken(i KeySecretPair) (
 	var a Access
 
 	var encryptedSecret string
-	row := db.Pool.QueryRow(context.Background(), `
+	row := sctx.DB.QueryRow(context.Background(), `
 	SELECT
     id,
     key,
@@ -72,7 +72,7 @@ func GenerateToken(i KeySecretPair) (
 }
 
 // Create creates new access resource.
-func Create(i Access) (
+func Create(sctx *srv.Ctx, i Access) (
 	*res.Success,
 	*res.Errors,
 ) {
@@ -89,7 +89,7 @@ func Create(i Access) (
 	}
 
 	// create root user
-	row := db.Pool.QueryRow(ctx, `
+	row := sctx.DB.QueryRow(ctx, `
   INSERT INTO
     access(
       key,

--- a/core/internal/pkg/api/api_endpoints.go
+++ b/core/internal/pkg/api/api_endpoints.go
@@ -12,13 +12,13 @@ import (
 	"core/internal/app/trait"
 	"core/internal/app/variation"
 	"core/internal/app/workspace"
-	"core/internal/pkg/server"
+	srv "core/internal/pkg/server"
 
 	"github.com/gin-gonic/gin"
 )
 
 // ApplyRoutes applies route from all packages to root handler
-func ApplyRoutes(sctx *server.Ctx, r *gin.Engine) {
+func ApplyRoutes(sctx *srv.Ctx, r *gin.Engine) {
 	ApplyMetrics(r)
 	root := r.Group("/")
 	access.ApplyRoutes(root)

--- a/core/internal/pkg/api/api_endpoints.go
+++ b/core/internal/pkg/api/api_endpoints.go
@@ -21,7 +21,7 @@ import (
 func ApplyRoutes(sctx *srv.Ctx, r *gin.Engine) {
 	ApplyMetrics(r)
 	root := r.Group("/")
-	access.ApplyRoutes(root)
+	access.ApplyRoutes(sctx, root)
 	environment.ApplyRoutes(root)
 	flag.ApplyRoutes(root)
 	healthcheck.ApplyRoutes(root)

--- a/core/internal/pkg/api/api_server.go
+++ b/core/internal/pkg/api/api_server.go
@@ -1,7 +1,7 @@
 package api
 
 import (
-	"core/internal/pkg/server"
+	srv "core/internal/pkg/server"
 	"strconv"
 
 	"github.com/gin-contrib/logger"
@@ -15,7 +15,7 @@ type Config struct {
 }
 
 // New initialize a new gin-based HTTP server
-func New(sctx *server.Ctx, cfg Config) {
+func New(sctx *srv.Ctx, cfg Config) {
 	if !cfg.Verbose {
 		gin.SetMode(gin.ReleaseMode)
 	}

--- a/core/internal/pkg/server/server_cleanup.go
+++ b/core/internal/pkg/server/server_cleanup.go
@@ -1,0 +1,6 @@
+package server
+
+func Cleanup(sctx *Ctx) {
+	sctx.DB.Close()
+	sctx.Cache.Close()
+}


### PR DESCRIPTION
## Context

In this PR, we start using the `server` package created in [PR #48](https://github.com/flagbase/flagbase/pull/49) within the access module.

## Changes

This PR introduces the following changes:
* Use injected `server.Ctx` within access module 
* Refactor server import alias (srv)

## Tasks

I've completed the following tasks:
- [x] Signed the Contributers License Agreement (CLA)
- [ ] Added/updated tests
- [ ] Added/updated docs
