### PR TITLE
OSS-84: update segment rules to be per-environment

### DIFF
--- a/core/api/swagger/swagger.yaml
+++ b/core/api/swagger/swagger.yaml
@@ -1962,7 +1962,7 @@ paths:
       tags:
         - segments
       description: Delete an existing user segment.
-  '/segment-rules/{workspaceKey}/{projectKey}/{segmentKey}':
+  '/segment-rules/{workspaceKey}/{projectKey}/{segmentKey}/{envKey}':
     parameters:
       - name: projectKey
         in: path
@@ -1982,6 +1982,12 @@ paths:
         in: path
         required: true
         description: The workspace key
+      - schema:
+          type: string
+        name: envKey
+        in: path
+        required: true
+        description: The environment key
     get:
       summary: List segment rules
       tags:
@@ -2026,7 +2032,7 @@ paths:
             schema:
               $ref: '#/components/schemas/SegmentRule'
         description: Segment Rules
-  '/segment-rules/{workspaceKey}/{projectKey}/{segmentKey}/{ruleKey}':
+  '/segment-rules/{workspaceKey}/{projectKey}/{segmentKey}/{envKey}/{ruleKey}':
     parameters:
       - name: projectKey
         in: path
@@ -2052,6 +2058,11 @@ paths:
         in: path
         required: true
         description: The workspace key
+      - schema:
+          type: string
+        name: envKey
+        in: path
+        required: true
     get:
       summary: Get segment rule
       tags:

--- a/core/internal/app/segmentrule/segmentrule_api.go
+++ b/core/internal/app/segmentrule/segmentrule_api.go
@@ -19,6 +19,7 @@ func ApplyRoutes(sctx *srv.Ctx, r *gin.RouterGroup) {
 		rsc.WorkspaceKey,
 		rsc.ProjectKey,
 		rsc.SegmentKey,
+		rsc.EnvironmentKey,
 	)
 	resourcePath := httputil.AppendPath(
 		rootPath,
@@ -46,6 +47,7 @@ func listAPIHandler(sctx *srv.Ctx, ctx *gin.Context) {
 		httputil.GetParam(ctx, rsc.WorkspaceKey),
 		httputil.GetParam(ctx, rsc.ProjectKey),
 		httputil.GetParam(ctx, rsc.SegmentKey),
+		httputil.GetParam(ctx, rsc.EnvironmentKey),
 	)
 	if !_err.IsEmpty() {
 		e.Extend(_err)
@@ -80,6 +82,7 @@ func createAPIHandler(sctx *srv.Ctx, ctx *gin.Context) {
 		httputil.GetParam(ctx, rsc.WorkspaceKey),
 		httputil.GetParam(ctx, rsc.ProjectKey),
 		httputil.GetParam(ctx, rsc.SegmentKey),
+		httputil.GetParam(ctx, rsc.EnvironmentKey),
 	)
 	if !_err.IsEmpty() {
 		e.Extend(_err)
@@ -108,6 +111,7 @@ func getAPIHandler(sctx *srv.Ctx, ctx *gin.Context) {
 		httputil.GetParam(ctx, rsc.WorkspaceKey),
 		httputil.GetParam(ctx, rsc.ProjectKey),
 		httputil.GetParam(ctx, rsc.SegmentKey),
+		httputil.GetParam(ctx, rsc.EnvironmentKey),
 		httputil.GetParam(ctx, rsc.RuleKey),
 	)
 	if !_err.IsEmpty() {
@@ -143,6 +147,7 @@ func updateAPIHandler(sctx *srv.Ctx, ctx *gin.Context) {
 		httputil.GetParam(ctx, rsc.WorkspaceKey),
 		httputil.GetParam(ctx, rsc.ProjectKey),
 		httputil.GetParam(ctx, rsc.SegmentKey),
+		httputil.GetParam(ctx, rsc.EnvironmentKey),
 		httputil.GetParam(ctx, rsc.RuleKey),
 	)
 	if !_err.IsEmpty() {
@@ -172,6 +177,7 @@ func deleteAPIHandler(sctx *srv.Ctx, ctx *gin.Context) {
 		httputil.GetParam(ctx, rsc.WorkspaceKey),
 		httputil.GetParam(ctx, rsc.ProjectKey),
 		httputil.GetParam(ctx, rsc.SegmentKey),
+		httputil.GetParam(ctx, rsc.EnvironmentKey),
 		httputil.GetParam(ctx, rsc.RuleKey),
 	); !err.IsEmpty() {
 		e.Extend(err)

--- a/core/internal/app/segmentrule/segmentrule_service.go
+++ b/core/internal/app/segmentrule/segmentrule_service.go
@@ -18,6 +18,7 @@ func List(
 	workspaceKey rsc.Key,
 	projectKey rsc.Key,
 	segmentKey rsc.Key,
+	environmentKey rsc.Key,
 ) (*res.Success, *res.Errors) {
 	var o []SegmentRule
 	var e res.Errors
@@ -42,16 +43,19 @@ func List(
   FROM
     workspace w,
     project p,
+    environment e,
     segment s,
     segment_rule sr
   WHERE
     w.key = $1 AND
     p.key = $2 AND
     s.key = $3 AND
+    e.key = $4 AND
     p.workspace_id = w.id AND
     s.project_id = p.id AND
+    s.environment_id = e.id AND
     sr.segment_id = s.id
-  `, workspaceKey, projectKey, segmentKey)
+  `, workspaceKey, projectKey, segmentKey, environmentKey)
 	if err != nil {
 		e.Append(cons.ErrorNotFound, err.Error())
 	}
@@ -83,6 +87,7 @@ func Create(
 	workspaceKey rsc.Key,
 	projectKey rsc.Key,
 	segmentKey rsc.Key,
+	environmentKey rsc.Key,
 ) (*res.Success, *res.Errors) {
 	var o SegmentRule
 	var e res.Errors
@@ -105,7 +110,8 @@ func Create(
       trait_value,
       operator,
       negate,
-      project_id
+      project_id,
+      environment_id,
     )
   VALUES
     ($1, $2, $3, $4, $5, (
@@ -119,6 +125,17 @@ func Create(
           s.key = $8 AND
           p.workspace_id = w.id AND
           s.project_id = p.id
+      ), (
+        SELECT
+          e.id
+        FROM
+          workspace w, project p, environment e
+        WHERE
+          w.key = $6 AND
+          p.key = $7 AND
+          e.key = $9 AND
+          p.workspace_id = w.id AND
+          e.project_id = p.id
       )
     )
   RETURNING
@@ -136,6 +153,7 @@ func Create(
 		workspaceKey,
 		projectKey,
 		segmentKey,
+		environmentKey,
 	)
 	if err := row.Scan(
 		&o.ID,
@@ -172,6 +190,7 @@ func Get(
 	workspaceKey rsc.Key,
 	projectKey rsc.Key,
 	segmentKey rsc.Key,
+	environmentKey rsc.Key,
 	segmentRuleKey rsc.Key,
 ) (*res.Success, *res.Errors) {
 	var e res.Errors
@@ -181,6 +200,7 @@ func Get(
 		workspaceKey,
 		projectKey,
 		segmentKey,
+		environmentKey,
 		segmentRuleKey,
 	)
 	if err != nil {
@@ -210,6 +230,7 @@ func Update(
 	workspaceKey rsc.Key,
 	projectKey rsc.Key,
 	segmentKey rsc.Key,
+	environmentKey rsc.Key,
 	segmentRuleKey rsc.Key,
 ) (*res.Success, *res.Errors) {
 	var o SegmentRule
@@ -224,6 +245,7 @@ func Update(
 		workspaceKey,
 		projectKey,
 		segmentKey,
+		environmentKey,
 		segmentRuleKey,
 	)
 	if err != nil {
@@ -282,6 +304,7 @@ func Delete(
 	workspaceKey rsc.Key,
 	projectKey rsc.Key,
 	segmentKey rsc.Key,
+	environmentKey rsc.Key,
 	segmentRuleKey rsc.Key,
 ) *res.Errors {
 	var e res.Errors
@@ -295,6 +318,7 @@ func Delete(
 		workspaceKey,
 		projectKey,
 		segmentKey,
+		environmentKey,
 		segmentRuleKey,
 	)
 	if err != nil {

--- a/core/internal/app/segmentrule/segmentrule_util.go
+++ b/core/internal/app/segmentrule/segmentrule_util.go
@@ -12,6 +12,7 @@ func getResource(
 	workspaceKey rsc.Key,
 	projectKey rsc.Key,
 	segmentKey rsc.Key,
+	environmentKey rsc.Key,
 	segmentRuleKey rsc.Key,
 ) (*SegmentRule, error) {
 	var o SegmentRule
@@ -27,19 +28,23 @@ func getResource(
       workspace w,
       project p,
       segment s,
+      environment e,
       segment_rule sr
     WHERE
       w.key = $1 AND
       p.key = $2 AND
       s.key = $3 AND
-      sr.key = $4 AND
+      e.key = $4 AND
+      sr.key = $5 AND
       p.workspace_id = w.id AND
       s.project_id = p.id AND
+      sr.environment_id = e.id AND
       sr.segment_id = s.id
     `,
 		workspaceKey,
 		projectKey,
 		segmentKey,
+		environmentKey,
 		segmentRuleKey,
 	)
 	if err := row.Scan(

--- a/core/migrations/000009_init_segment_rule.up.sql
+++ b/core/migrations/000009_init_segment_rule.up.sql
@@ -18,8 +18,9 @@ CREATE TABLE segment_rule (
   negate BOOLEAN DEFAULT FALSE,
   -- references
   segment_id resource_id REFERENCES segment (id),
+  environment_id resource_id REFERENCES environment (id),
   -- contraints
-  CONSTRAINT segment_rule_key UNIQUE(key, segment_id)
+  CONSTRAINT segment_rule_key UNIQUE(key, segment_id, environment_id)
 );
 
 END;


### PR DESCRIPTION
## Context

We want to have different segment rules per environment (similar to targeting rules). This allows you to use segments to target users in different application environments (staging → employees, prod → customers etc). 

[https://flagbase.atlassian.net/browse/OSS-84](https://flagbase.atlassian.net/browse/OSS-84)

## Changes

This PR introduces the following changes:
* Updated endpoints
* Updated services
* Updated service utils
* Updated swagger docs

## Tasks

I've completed the following tasks:
- [x] Signed the Contributers License Agreement (CLA)
- [ ] Added/updated tests
- [ ] Added/updated docs
