### PR TITLE
FIX: update exposed port for core db in docker-compose

### DIFF
--- a/core/docker-compose.yml
+++ b/core/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     image: postgres
     restart: always
     ports:
-      - 5432:5432
+      - 5433:5432
     environment:
       POSTGRES_DB: flagbase
       POSTGRES_USER: flagbase


### PR DESCRIPTION
## Context

com.docker.backend now runs on port 5432, conflicting with postgres

## Changes

This PR introduces the following changes:
* Update the exposed db port in `core/docker-compose.yml`

## Tasks

I've completed the following tasks:
- [x] Signed the Contributers License Agreement (CLA)
- [ ] Added/updated tests
- [ ] Added/updated docs
