### PR TITLE
OSS-87: nest segment-rules in segment route

### DIFF
--- a/core/api/swagger/swagger.yaml
+++ b/core/api/swagger/swagger.yaml
@@ -1905,7 +1905,7 @@ paths:
       tags:
         - segments
       description: Delete an existing user segment.
-  '/segment-rules/{workspaceKey}/{projectKey}/{segmentKey}/{envKey}':
+  '/segments/{workspaceKey}/{projectKey}/{segmentKey}/rules/{envKey}':
     parameters:
       - name: projectKey
         in: path
@@ -1975,7 +1975,7 @@ paths:
             schema:
               $ref: '#/components/schemas/SegmentRule'
         description: Segment Rules
-  '/segment-rules/{workspaceKey}/{projectKey}/{segmentKey}/{envKey}/{ruleKey}':
+  '/segments/{workspaceKey}/{projectKey}/{segmentKey}/rules/{envKey}/{ruleKey}':
     parameters:
       - name: projectKey
         in: path

--- a/core/internal/app/segment/segment_api.go
+++ b/core/internal/app/segment/segment_api.go
@@ -1,6 +1,7 @@
 package segment
 
 import (
+	"core/internal/app/segmentrule"
 	cons "core/internal/pkg/constants"
 	"core/internal/pkg/httputil"
 	rsc "core/internal/pkg/resource"
@@ -15,6 +16,9 @@ import (
 // ApplyRoutes segment route handlers
 func ApplyRoutes(sctx *srv.Ctx, r *gin.RouterGroup) {
 	routes := r.Group(rsc.RouteSegment)
+
+	segmentrule.ApplyRoutes(sctx, routes)
+
 	rootPath := httputil.BuildPath(
 		rsc.WorkspaceKey,
 		rsc.ProjectKey,

--- a/core/internal/app/segmentrule/segmentrule_api.go
+++ b/core/internal/app/segmentrule/segmentrule_api.go
@@ -14,12 +14,17 @@ import (
 
 // ApplyRoutes segment route handlers
 func ApplyRoutes(sctx *srv.Ctx, r *gin.RouterGroup) {
-	routes := r.Group(rsc.RouteSegmentRule)
-	rootPath := httputil.BuildPath(
-		rsc.WorkspaceKey,
-		rsc.ProjectKey,
+	routes := r.Group("/")
+	rootPath := httputil.AppendPath(
+		httputil.AppendRoute(
+			httputil.BuildPath(
+				rsc.WorkspaceKey,
+				rsc.ProjectKey,
+				rsc.SegmentKey,
+			),
+			rsc.RouteRule,
+		),
 		rsc.EnvironmentKey,
-		rsc.SegmentKey,
 	)
 	resourcePath := httputil.AppendPath(
 		rootPath,

--- a/core/internal/pkg/api/api_endpoints.go
+++ b/core/internal/pkg/api/api_endpoints.go
@@ -8,7 +8,6 @@ import (
 	"core/internal/app/identity"
 	"core/internal/app/project"
 	"core/internal/app/segment"
-	"core/internal/app/segmentrule"
 	"core/internal/app/targeting"
 	"core/internal/app/targetingrule"
 	"core/internal/app/trait"
@@ -34,7 +33,6 @@ func ApplyRoutes(sctx *srv.Ctx, r *gin.Engine) {
 	targetingrule.ApplyRoutes(sctx, root)
 	trait.ApplyRoutes(sctx, root)
 	segment.ApplyRoutes(sctx, root)
-	segmentrule.ApplyRoutes(sctx, root)
 	variation.ApplyRoutes(sctx, root)
 	workspace.ApplyRoutes(sctx, root)
 }

--- a/core/internal/pkg/httputil/params.go
+++ b/core/internal/pkg/httputil/params.go
@@ -26,3 +26,19 @@ func AppendPath(rootPath string, params ...rsc.Key) string {
 		params...,
 	)
 }
+
+// BuildRoute constructs a path given the respective routes
+func BuildRoute(routes ...string) string {
+	if len(routes) == 1 {
+		return routes[0]
+	}
+
+	return routes[0] + "/" + BuildRoute(routes[1:]...)
+}
+
+// AppendRoute helper which appends extra route to an existing path
+func AppendRoute(rootPath string, routes ...string) string {
+	return rootPath + "/" + BuildRoute(
+		routes...,
+	)
+}

--- a/core/internal/pkg/resource/resource_route.go
+++ b/core/internal/pkg/resource/resource_route.go
@@ -25,4 +25,6 @@ const (
 	RouteTargeting string = "targeting"
 	// RouteTargetingRule points to the targeting rule resource
 	RouteTargetingRule string = "targeting-rules"
+	// RouteRule points to the rule resource
+	RouteRule string = "rules"
 )


### PR DESCRIPTION
## Context

Nest segment-rules in segment route as it makes sense semantically.

### Before
`/segment-rules/{workspaceKey}/{projectKey}/{segmentKey}/{envKey}/{ruleKey}`
### After
`/segments/{workspaceKey}/{projectKey}/{segmentKey}/rules/{envKey}/{ruleKey}`

## Changes

This PR introduces the following changes:
* Remove `segment-rules` from root endpoints in `api_endpoints.go`
* Apply `segment-rules` routes from segment handlers in `segment_api.go`
* Update swagger.yaml

## Tasks

I've completed the following tasks:
- [x] Signed the Contributers License Agreement (CLA)
- [ ] Added/updated tests
- [ ] Added/updated docs
