### PR TITLE
OSS-87: nest targeting-rules routes in targeting endpoint

### DIFF
--- a/core/api/swagger/swagger.yaml
+++ b/core/api/swagger/swagger.yaml
@@ -1424,7 +1424,7 @@ paths:
       description: Delete a targeting configuration for a particular flag per environment
       tags:
         - targeting
-  '/targeting-rules/{workspaceKey}/{projectKey}/{envKey}/{flagKey}':
+  '/targeting/{workspaceKey}/{projectKey}/{envKey}/{flagKey}/rules':
     parameters:
       - name: projectKey
         in: path
@@ -1496,7 +1496,7 @@ paths:
             schema:
               $ref: '#/components/schemas/TargetingRule'
         description: Targeting Rule
-  '/targeting-rules/{workspaceKey}/{projectKey}/{envKey}/{flagKey}/{ruleKey}':
+  '/targeting/{workspaceKey}/{projectKey}/{envKey}/{flagKey}/rules/{ruleKey}':
     parameters:
       - name: projectKey
         in: path

--- a/core/internal/app/segment/segment_api.go
+++ b/core/internal/app/segment/segment_api.go
@@ -17,8 +17,6 @@ import (
 func ApplyRoutes(sctx *srv.Ctx, r *gin.RouterGroup) {
 	routes := r.Group(rsc.RouteSegment)
 
-	segmentrule.ApplyRoutes(sctx, routes)
-
 	rootPath := httputil.BuildPath(
 		rsc.WorkspaceKey,
 		rsc.ProjectKey,
@@ -33,6 +31,7 @@ func ApplyRoutes(sctx *srv.Ctx, r *gin.RouterGroup) {
 	routes.GET(resourcePath, httputil.Handler(sctx, getAPIHandler))
 	routes.PATCH(resourcePath, httputil.Handler(sctx, updateAPIHandler))
 	routes.DELETE(resourcePath, httputil.Handler(sctx, deleteAPIHandler))
+	segmentrule.ApplyRoutes(sctx, routes)
 }
 
 func listAPIHandler(sctx *srv.Ctx, ctx *gin.Context) {

--- a/core/internal/app/targeting/targeting_api.go
+++ b/core/internal/app/targeting/targeting_api.go
@@ -1,6 +1,7 @@
 package targeting
 
 import (
+	"core/internal/app/targetingrule"
 	cons "core/internal/pkg/constants"
 	"core/internal/pkg/httputil"
 	rsc "core/internal/pkg/resource"
@@ -26,6 +27,7 @@ func ApplyRoutes(sctx *srv.Ctx, r *gin.RouterGroup) {
 	routes.GET(rootPath, httputil.Handler(sctx, getAPIHandler))
 	routes.PATCH(rootPath, httputil.Handler(sctx, updateAPIHandler))
 	routes.DELETE(rootPath, httputil.Handler(sctx, deleteAPIHandler))
+	targetingrule.ApplyRoutes(sctx, routes)
 }
 
 func createAPIHandler(sctx *srv.Ctx, ctx *gin.Context) {

--- a/core/internal/app/targetingrule/targetingrule_api.go
+++ b/core/internal/app/targetingrule/targetingrule_api.go
@@ -14,17 +14,21 @@ import (
 
 // ApplyRoutes segment route handlers
 func ApplyRoutes(sctx *srv.Ctx, r *gin.RouterGroup) {
-	routes := r.Group(rsc.RouteTargetingRule)
-	rootPath := httputil.BuildPath(
-		rsc.WorkspaceKey,
-		rsc.ProjectKey,
-		rsc.EnvironmentKey,
-		rsc.FlagKey,
+	routes := r.Group("/")
+	rootPath := httputil.AppendRoute(
+		httputil.BuildPath(
+			rsc.WorkspaceKey,
+			rsc.ProjectKey,
+			rsc.EnvironmentKey,
+			rsc.FlagKey,
+		),
+		rsc.RouteRule,
 	)
 	resourcePath := httputil.AppendPath(
 		rootPath,
 		rsc.RuleKey,
 	)
+
 	routes.GET(rootPath, httputil.Handler(sctx, listAPIHandler))
 	routes.POST(rootPath, httputil.Handler(sctx, createAPIHandler))
 	routes.GET(resourcePath, httputil.Handler(sctx, getAPIHandler))

--- a/core/internal/pkg/api/api_endpoints.go
+++ b/core/internal/pkg/api/api_endpoints.go
@@ -9,7 +9,6 @@ import (
 	"core/internal/app/project"
 	"core/internal/app/segment"
 	"core/internal/app/targeting"
-	"core/internal/app/targetingrule"
 	"core/internal/app/trait"
 	"core/internal/app/variation"
 	"core/internal/app/workspace"
@@ -30,7 +29,6 @@ func ApplyRoutes(sctx *srv.Ctx, r *gin.Engine) {
 	identity.ApplyRoutes(sctx, root)
 	project.ApplyRoutes(sctx, root)
 	targeting.ApplyRoutes(sctx, root)
-	targetingrule.ApplyRoutes(sctx, root)
 	trait.ApplyRoutes(sctx, root)
 	segment.ApplyRoutes(sctx, root)
 	variation.ApplyRoutes(sctx, root)


### PR DESCRIPTION
## Context

Nest targeting-rules in targeting route as it makes sense semantically.

### Before
* `/targeting-rules/{workspaceKey}/{projectKey}/{envKey}/{flagKey}`
* `/targeting-rules/{workspaceKey}/{projectKey}/{envKey}/{flagKey}/{ruleKey}`

### After
* `/targeting/{workspaceKey}/{projectKey}/{envKey}/{flagKey}/rules`
* `/targeting/{workspaceKey}/{projectKey}/{envKey}/{flagKey}/rules/{ruleKey}`

## Changes

This PR introduces the following changes:
* Remove targeting-rules from root endpoints in api_endpoints.go
* Apply targeting-rules routes from targeting handlers in targeting_api.go
* Update swagger.yaml

## Tasks

I've completed the following tasks:
- [x] Signed the Contributers License Agreement (CLA)
- [ ] Added/updated tests
- [ ] Added/updated docs
