### PR TITLE
OSS-87: nest variation routes in flag endpoint

### DIFF
--- a/core/api/swagger/swagger.yaml
+++ b/core/api/swagger/swagger.yaml
@@ -1032,7 +1032,7 @@ paths:
       tags:
         - flags
       description: Delete an existing flag.
-  '/variations/{workspaceKey}/{projectKey}/{flagKey}':
+  '/flags/{workspaceKey}/{projectKey}/{flagKey}/variations':
     parameters:
       - name: flagKey
         in: path
@@ -1100,7 +1100,7 @@ paths:
       description: Create a flag variation.
       requestBody:
         $ref: '#/components/requestBodies/Variation'
-  '/variations/{workspaceKey}/{projectKey}/{flagKey}/{variationKey}':
+  '/flags/{workspaceKey}/{projectKey}/{flagKey}/variations/{variationKey}':
     parameters:
       - name: projectKey
         in: path

--- a/core/internal/app/flag/flag_api.go
+++ b/core/internal/app/flag/flag_api.go
@@ -1,6 +1,7 @@
 package flag
 
 import (
+	"core/internal/app/variation"
 	cons "core/internal/pkg/constants"
 	"core/internal/pkg/httputil"
 	rsc "core/internal/pkg/resource"
@@ -29,6 +30,7 @@ func ApplyRoutes(sctx *srv.Ctx, r *gin.RouterGroup) {
 	routes.GET(resourcePath, httputil.Handler(sctx, getAPIHandler))
 	routes.PATCH(resourcePath, httputil.Handler(sctx, updateAPIHandler))
 	routes.DELETE(resourcePath, httputil.Handler(sctx, deleteAPIHandler))
+	variation.ApplyRoutes(sctx, routes)
 }
 
 func listAPIHandler(sctx *srv.Ctx, ctx *gin.Context) {

--- a/core/internal/app/variation/variation_api.go
+++ b/core/internal/app/variation/variation_api.go
@@ -14,11 +14,14 @@ import (
 
 // ApplyRoutes variation route handlers
 func ApplyRoutes(sctx *srv.Ctx, r *gin.RouterGroup) {
-	routes := r.Group(rsc.RouteVariation)
-	rootPath := httputil.BuildPath(
-		rsc.WorkspaceKey,
-		rsc.ProjectKey,
-		rsc.FlagKey,
+	routes := r.Group("")
+	rootPath := httputil.AppendRoute(
+		httputil.BuildPath(
+			rsc.WorkspaceKey,
+			rsc.ProjectKey,
+			rsc.FlagKey,
+		),
+		rsc.RouteVariation,
 	)
 	resourcePath := httputil.AppendPath(
 		rootPath,

--- a/core/internal/pkg/api/api_endpoints.go
+++ b/core/internal/pkg/api/api_endpoints.go
@@ -10,7 +10,6 @@ import (
 	"core/internal/app/segment"
 	"core/internal/app/targeting"
 	"core/internal/app/trait"
-	"core/internal/app/variation"
 	"core/internal/app/workspace"
 	"core/internal/pkg/httpmetrics"
 	srv "core/internal/pkg/server"
@@ -31,6 +30,5 @@ func ApplyRoutes(sctx *srv.Ctx, r *gin.Engine) {
 	targeting.ApplyRoutes(sctx, root)
 	trait.ApplyRoutes(sctx, root)
 	segment.ApplyRoutes(sctx, root)
-	variation.ApplyRoutes(sctx, root)
 	workspace.ApplyRoutes(sctx, root)
 }


### PR DESCRIPTION
## Context

Nest variations in flag route as it makes sense semantically.

### Before

* `/variations/{workspaceKey}/{projectKey}/{flagKey}`
* `/variations/{workspaceKey}/{projectKey}/{flagKey}/{variationKey}`

### After

* `/flags/{workspaceKey}/{projectKey}/{flagKey}/variations`
* `/flags/{workspaceKey}/{projectKey}/{flagKey}/variations/{variationKey}`

## Changes

This PR introduces the following changes:
* Remove variations from root endpoints in api_endpoints.go
* Apply variations routes from flag handlers in flag_api.go
* Update swagger.yaml


## Tasks

I've completed the following tasks:
- [x] Signed the Contributers License Agreement (CLA)
- [ ] Added/updated tests
- [ ] Added/updated docs
