### PR TITLE
OSS-87: nest environment routes in project endpoint

### DIFF
--- a/core/api/swagger/swagger.yaml
+++ b/core/api/swagger/swagger.yaml
@@ -272,7 +272,7 @@ paths:
       tags:
         - projects
       description: Delete an existing project.
-  '/environments/{workspaceKey}/{projectKey}/{envKey}':
+  '/projects/{workspaceKey}/{projectKey}/environments/{envKey}':
     parameters:
       - name: projectKey
         in: path
@@ -786,7 +786,7 @@ paths:
         $ref: '#/components/requestBodies/AccessPairInput'
       tags:
         - project-access
-  '/environments/{workspaceKey}/{projectKey}/{envKey}/access':
+  '/projects/{workspaceKey}/{projectKey}/environments/{envKey}/access':
     parameters:
       - name: envKey
         in: path
@@ -869,7 +869,7 @@ paths:
       description: Delete an existing environment access link.
       requestBody:
         $ref: '#/components/requestBodies/AccessPairInput'
-  '/environments/{workspaceKey}/{projectKey}':
+  '/projects/{workspaceKey}/{projectKey}/environments':
     parameters:
       - name: projectKey
         in: path

--- a/core/internal/app/environment/environment_api.go
+++ b/core/internal/app/environment/environment_api.go
@@ -14,10 +14,13 @@ import (
 
 // ApplyRoutes environment route handlers
 func ApplyRoutes(sctx *srv.Ctx, r *gin.RouterGroup) {
-	routes := r.Group(rsc.RouteEnvironment)
-	rootPath := httputil.BuildPath(
-		rsc.WorkspaceKey,
-		rsc.ProjectKey,
+	routes := r.Group("/")
+	rootPath := httputil.BuildRoute(
+		httputil.BuildPath(
+			rsc.WorkspaceKey,
+			rsc.ProjectKey,
+		),
+		rsc.RouteEnvironment,
 	)
 	resourcePath := httputil.AppendPath(
 		rootPath,

--- a/core/internal/app/project/project_api.go
+++ b/core/internal/app/project/project_api.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"core/internal/app/environment"
 	cons "core/internal/pkg/constants"
 	"core/internal/pkg/httputil"
 	rsc "core/internal/pkg/resource"
@@ -28,6 +29,7 @@ func ApplyRoutes(sctx *srv.Ctx, r *gin.RouterGroup) {
 	routes.GET(resourcePath, httputil.Handler(sctx, getAPIHandler))
 	routes.PATCH(resourcePath, httputil.Handler(sctx, updateAPIHandler))
 	routes.DELETE(resourcePath, httputil.Handler(sctx, deleteAPIHandler))
+	environment.ApplyRoutes(sctx, routes)
 }
 
 func listAPIHandler(sctx *srv.Ctx, ctx *gin.Context) {

--- a/core/internal/app/variation/variation_api.go
+++ b/core/internal/app/variation/variation_api.go
@@ -14,7 +14,7 @@ import (
 
 // ApplyRoutes variation route handlers
 func ApplyRoutes(sctx *srv.Ctx, r *gin.RouterGroup) {
-	routes := r.Group("")
+	routes := r.Group("/")
 	rootPath := httputil.AppendRoute(
 		httputil.BuildPath(
 			rsc.WorkspaceKey,

--- a/core/internal/pkg/api/api_endpoints.go
+++ b/core/internal/pkg/api/api_endpoints.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"core/internal/app/access"
-	"core/internal/app/environment"
 	"core/internal/app/flag"
 	"core/internal/app/healthcheck"
 	"core/internal/app/identity"
@@ -22,7 +21,6 @@ func ApplyRoutes(sctx *srv.Ctx, r *gin.Engine) {
 	httpmetrics.ApplyMetrics(r, "api")
 	root := r.Group("/")
 	access.ApplyRoutes(sctx, root)
-	environment.ApplyRoutes(sctx, root)
 	flag.ApplyRoutes(sctx, root)
 	healthcheck.ApplyRoutes(sctx, root)
 	identity.ApplyRoutes(sctx, root)


### PR DESCRIPTION
## Context

Nest environments in project route as it makes sense semantically.

### Before
* `/environments/{workspaceKey}/{projectKey}/{envKey}`
* `/environments/{workspaceKey}/{projectKey}/{envKey}/access`
* `/environments/{workspaceKey}/{projectKey}`

### After
* `/projects/{workspaceKey}/{projectKey}/environments/{envKey}`
* `/projects/{workspaceKey}/{projectKey}/environments/{envKey}/access`
* `/projects/{workspaceKey}/{projectKey}/environments`

## Changes

This PR introduces the following changes:
* Remove environments from root endpoints in api_endpoints.go
* Apply environments routes from project handlers in project_api.go
* Update swagger.yaml


## Tasks

I've completed the following tasks:
- [x] Signed the Contributers License Agreement (CLA)
- [ ] Added/updated tests
- [ ] Added/updated docs
