### PR TITLE
OSS-86: added polling worker

### DIFF
--- a/core/docker-compose.yml
+++ b/core/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     command: ["air"]
     ports:
       - 5051:5051
+      - 7051:7051
+      - 9051:9051
     volumes:
       - ./:/go/src/github.com/flagbase/flagbase/core
     depends_on:

--- a/core/internal/pkg/constants/defaults.go
+++ b/core/internal/pkg/constants/defaults.go
@@ -10,7 +10,7 @@ var (
 		"db:5432/flagbase" +
 		"?sslmode=disable"
 	// DefaultRedisAddr default redis address
-	DefaultRedisAddr string = "localhost:6379"
+	DefaultRedisAddr string = "redis:6379"
 	// DefaultRedisPassword default redis password
 	DefaultRedisPassword string = ""
 	// DefaultRedisDB default redis database number
@@ -34,6 +34,8 @@ var (
 	JWTKey string = "bad_secret"
 	// JWTExpiryMinutes default JWT lifetime (in minutes)
 	JWTExpiryMinutes time.Duration = 5000
+	// DefaultCacheExpiry default Cache lifetime (in seconds)
+	DefaultCacheExpiry time.Duration = 300000000000
 	// DefaultPrometheus for if prometheus is setup
 	DefaultPrometheus bool = false
 )

--- a/core/internal/pkg/polling/polling.go
+++ b/core/internal/pkg/polling/polling.go
@@ -1,4 +1,4 @@
-package evaluation
+package polling
 
 import rsc "core/internal/pkg/resource"
 

--- a/core/internal/pkg/polling/polling_endpoints.go
+++ b/core/internal/pkg/polling/polling_endpoints.go
@@ -1,9 +1,14 @@
 package polling
 
 import (
+	cons "core/internal/pkg/constants"
 	"core/internal/pkg/httpmetrics"
 	"core/internal/pkg/httputil"
+	rsc "core/internal/pkg/resource"
 	srv "core/internal/pkg/server"
+	"core/pkg/evaluator"
+	res "core/pkg/response"
+	"net/http"
 
 	"github.com/gin-gonic/gin"
 )
@@ -11,15 +16,97 @@ import (
 // ApplyRoutes applies route from all packages to root handler
 func ApplyRoutes(sctx *srv.Ctx, r *gin.Engine) {
 	httpmetrics.ApplyMetrics(r, "polling")
-	routes := r.Group("")
-	routes.GET("/flags/raw", httputil.Handler(sctx, getRawFlags))
-	routes.POST("/flags/evaluated", httputil.Handler(sctx, evaluateFlags))
+	routes := r.Group(rsc.RoutePolling)
+	rootPath := httputil.BuildPath(
+		rsc.WorkspaceKey,
+		rsc.ProjectKey,
+		rsc.EnvironmentKey,
+	)
+
+	routes.GET(rootPath, httputil.Handler(sctx, getEvaluationAPIHandler))
+	routes.POST(rootPath, httputil.Handler(sctx, evaluateAPIHandler))
 }
 
-func getRawFlags(sctx *srv.Ctx, ctx *gin.Context) {
-	// TODO (OSS-81)
+func getEvaluationAPIHandler(sctx *srv.Ctx, ctx *gin.Context) {
+	var e res.Errors
+
+	atk, err := httputil.ExtractATK(ctx)
+	if err != nil {
+		e.Append(cons.ErrorAuth, err.Error())
+	}
+
+	etag := ctx.Request.Header.Get("ETag")
+
+	data, retag, _err := Get(
+		sctx,
+		atk,
+		etag,
+		RootArgs{
+			WorkspaceKey:   httputil.GetParam(ctx, rsc.WorkspaceKey),
+			ProjectKey:     httputil.GetParam(ctx, rsc.ProjectKey),
+			EnvironmentKey: httputil.GetParam(ctx, rsc.EnvironmentKey),
+		},
+	)
+	if !_err.IsEmpty() {
+		e.Extend(_err)
+	}
+
+	ctx.Header("ETag", retag)
+	statusCode := http.StatusOK
+	if _err.IsEmpty() && retag == etag {
+		statusCode = http.StatusNotModified
+	}
+
+	httputil.Send(
+		ctx,
+		statusCode,
+		data,
+		http.StatusInternalServerError,
+		e,
+	)
 }
 
-func evaluateFlags(sctx *srv.Ctx, ctx *gin.Context) {
-	// TODO (OSS-81)
+func evaluateAPIHandler(sctx *srv.Ctx, ctx *gin.Context) {
+	var e res.Errors
+
+	atk, err := httputil.ExtractATK(ctx)
+	if err != nil {
+		e.Append(cons.ErrorAuth, err.Error())
+	}
+
+	etag := ctx.Request.Header.Get("ETag")
+
+	var i evaluator.Context
+	if err := ctx.BindJSON(&i); err != nil {
+		e.Append(cons.ErrorInternal, err.Error())
+	}
+
+	data, retag, _err := Evaluate(
+		sctx,
+		atk,
+		etag,
+		i,
+		RootArgs{
+			WorkspaceKey:   httputil.GetParam(ctx, rsc.WorkspaceKey),
+			ProjectKey:     httputil.GetParam(ctx, rsc.ProjectKey),
+			EnvironmentKey: httputil.GetParam(ctx, rsc.EnvironmentKey),
+		},
+	)
+	if !_err.IsEmpty() {
+		e.Extend(_err)
+	}
+
+	ctx.Header("ETag", retag)
+	statusCode := http.StatusOK
+	if _err.IsEmpty() && retag == etag {
+		statusCode = http.StatusNotModified
+	}
+
+	httputil.Send(
+		ctx,
+		statusCode,
+		data,
+		http.StatusInternalServerError,
+		e,
+	)
 }

--- a/core/internal/pkg/polling/polling_service.go
+++ b/core/internal/pkg/polling/polling_service.go
@@ -1,0 +1,107 @@
+package polling
+
+import (
+	"context"
+	rsc "core/internal/pkg/resource"
+	srv "core/internal/pkg/server"
+	"core/pkg/evaluator"
+	"core/pkg/hashutil"
+	res "core/pkg/response"
+)
+
+// Get returns a set raw (non-evaluated) flagsets
+// (*) atk: access_type <= service
+func Get(
+	sctx *srv.Ctx,
+	atk rsc.Token,
+	etag string,
+	a RootArgs,
+) (*res.Success, string, *res.Errors) {
+	var e res.Errors
+	var o *res.Success
+	ctx := context.Background()
+
+	retag := etag
+	cacheKey := hashutil.HashKeys(
+		"polling-get-raw-ruleset",
+		string(a.WorkspaceKey),
+		string(a.ProjectKey),
+		string(a.EnvironmentKey),
+	)
+	otag, _ := sctx.Cache.Get(ctx, cacheKey).Result()
+
+	if etag == "" || etag != otag {
+		r, _e, newETag := getAndSetCache(GetAndSetCacheArgs{
+			Sctx:     sctx,
+			Atk:      atk,
+			Ctx:      ctx,
+			RootArgs: a,
+			CacheKey: cacheKey,
+		})
+		if !_e.IsEmpty() {
+			e.Extend(&_e)
+		}
+		o = &r
+		retag = newETag
+	} else {
+		go getAndSetCache(GetAndSetCacheArgs{
+			Sctx:     sctx,
+			Atk:      atk,
+			Ctx:      ctx,
+			RootArgs: a,
+			CacheKey: cacheKey,
+		})
+	}
+
+	return o, retag, &e
+}
+
+// Evaluate returns an evaluated flagset given the user context
+// (*) atk: access_type <= service
+func Evaluate(
+	sctx *srv.Ctx,
+	atk rsc.Token,
+	etag string,
+	ectx evaluator.Context,
+	a RootArgs,
+) (*res.Success, string, *res.Errors) {
+	var e res.Errors
+	var o *res.Success
+	ctx := context.Background()
+
+	retag := etag
+	cacheKey := hashutil.HashKeys(
+		"polling-get-evaluated-ruleset",
+		string(a.WorkspaceKey),
+		string(a.ProjectKey),
+		string(a.EnvironmentKey),
+	)
+	otag, _ := sctx.Cache.Get(ctx, cacheKey).Result()
+
+	if etag == "" || etag != otag {
+		r, _e, newETag := evaluateAndSetCache(EvaluateAndSetCacheArgs{
+			Sctx:     sctx,
+			Atk:      atk,
+			Ctx:      ctx,
+			Ectx:     ectx,
+			RootArgs: a,
+			CacheKey: cacheKey,
+		})
+		if !_e.IsEmpty() {
+			e.Extend(&_e)
+		}
+		o = &r
+		retag = newETag
+	} else {
+		go evaluateAndSetCache(EvaluateAndSetCacheArgs{
+			Sctx:     sctx,
+			Atk:      atk,
+			Ctx:      ctx,
+			Ectx:     ectx,
+			RootArgs: a,
+			CacheKey: cacheKey,
+		})
+	}
+
+	return o, retag, &e
+}

--- a/core/internal/pkg/polling/polling_util.go
+++ b/core/internal/pkg/polling/polling_util.go
@@ -1,0 +1,115 @@
+package polling
+
+import (
+	"context"
+	"core/internal/app/evaluation"
+	cons "core/internal/pkg/constants"
+	rsc "core/internal/pkg/resource"
+	srv "core/internal/pkg/server"
+	"core/pkg/evaluator"
+	"core/pkg/hashutil"
+	res "core/pkg/response"
+	"encoding/json"
+)
+
+type GetAndSetCacheArgs struct {
+	Sctx     *srv.Ctx
+	Atk      rsc.Token
+	Ctx      context.Context
+	RootArgs RootArgs
+	CacheKey string
+}
+
+func getAndSetCache(args GetAndSetCacheArgs) (
+	res.Success,
+	res.Errors,
+	string,
+) {
+	var e res.Errors
+	var o *res.Success
+
+	r, err := evaluation.Get(
+		args.Sctx,
+		args.Atk,
+		evaluation.RootArgs{
+			WorkspaceKey:   args.RootArgs.WorkspaceKey,
+			ProjectKey:     args.RootArgs.ProjectKey,
+			EnvironmentKey: args.RootArgs.EnvironmentKey,
+		},
+	)
+	if !err.IsEmpty() {
+		e.Extend(err)
+	}
+
+	o = r
+
+	oBytes, _err := json.Marshal(o)
+	if _err != nil {
+		e.Append(cons.ErrorInternal, _err.Error())
+	}
+	retag := hashutil.HashKeys(
+		string(oBytes),
+	)
+	if err := args.Sctx.Cache.Set(
+		args.Ctx,
+		args.CacheKey,
+		retag,
+		cons.DefaultCacheExpiry,
+	).Err(); err != nil {
+		panic(err)
+	}
+
+	return *o, e, retag
+}
+
+type EvaluateAndSetCacheArgs struct {
+	Sctx     *srv.Ctx
+	Atk      rsc.Token
+	Ctx      context.Context
+	Ectx     evaluator.Context
+	RootArgs RootArgs
+	CacheKey string
+}
+
+func evaluateAndSetCache(args EvaluateAndSetCacheArgs) (
+	res.Success,
+	res.Errors,
+	string,
+) {
+	var e res.Errors
+	var o *res.Success
+
+	r, err := evaluation.Evaluate(
+		args.Sctx,
+		args.Atk,
+		args.Ectx,
+		evaluation.RootArgs{
+			WorkspaceKey:   args.RootArgs.WorkspaceKey,
+			ProjectKey:     args.RootArgs.ProjectKey,
+			EnvironmentKey: args.RootArgs.EnvironmentKey,
+		},
+	)
+	if !err.IsEmpty() {
+		e.Extend(err)
+	}
+
+	o = r
+
+	oBytes, _err := json.Marshal(o)
+	if _err != nil {
+		e.Append(cons.ErrorInternal, _err.Error())
+	}
+	retag := hashutil.HashKeys(
+		string(oBytes),
+	)
+	if err := args.Sctx.Cache.Set(
+		args.Ctx,
+		args.CacheKey,
+		retag,
+		cons.DefaultCacheExpiry,
+	).Err(); err != nil {
+		panic(err)
+	}
+
+	return *o, e, retag
+}

--- a/core/internal/pkg/resource/resource_route.go
+++ b/core/internal/pkg/resource/resource_route.go
@@ -29,4 +29,6 @@ const (
 	RouteRule string = "rules"
 	// RouteEvaluation points to the evaluation resource
 	RouteEvaluation string = "evaluation"
+	// Polling points to the polling worker
+	RoutePolling string = "polling"
 )


### PR DESCRIPTION
## Context

Connected evaluation service to polling worker. Also added `ETag` mechanism to cache polled responses.

## Changes

This PR introduces the following changes:
* Updated `core/pkg/internal/polling` package
* Update `core/docker-compose.yml` to expose polling and streaming ports

## Tasks

I've completed the following tasks:
- [x] Signed the Contributers License Agreement (CLA)
- [ ] Added/updated tests
- [ ] Added/updated docs
