### PR TITLE
OSS-97: use sdk key in polling service

### DIFF
--- a/core/internal/app/auth/auth_service.go
+++ b/core/internal/app/auth/auth_service.go
@@ -1,18 +1,29 @@
 package auth
 
 import (
+	"core/internal/pkg/httputil"
 	"core/internal/pkg/policy"
 	rsc "core/internal/pkg/resource"
 	srv "core/internal/pkg/server"
 	"errors"
 	"fmt"
+	"reflect"
 )
 
 // Authorize checks if an access token is of a desired type
 func Authorize(
+	sctx *srv.Ctx,
 	atk rsc.Token,
 	accessType rsc.AccessType,
 ) error {
+	// bypass auth for internal operations using secure runtime hash
+	if reflect.DeepEqual(
+		atk,
+		httputil.SecureOverideATK(sctx),
+	) {
+		return nil
+	}
+
 	a, err := getAccessFromToken(atk)
 	if err != nil {
 		return err
@@ -38,6 +49,14 @@ func Enforce(
 	resourceType rsc.Type,
 	accessType rsc.AccessType,
 ) error {
+	// bypass auth for internal operations using secure runtime hash
+	if reflect.DeepEqual(
+		atk,
+		httputil.SecureOverideATK(sctx),
+	) {
+		return nil
+	}
+
 	a, err := getAccessFromToken(atk)
 	if err != nil {
 		return err

--- a/core/internal/app/environment/environment_service.go
+++ b/core/internal/app/environment/environment_service.go
@@ -21,7 +21,7 @@ func List(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := auth.Authorize(atk, rsc.AccessService); err != nil {
+	if err := auth.Authorize(sctx, atk, rsc.AccessService); err != nil {
 		e.Append(cons.ErrorAuth, err.Error())
 		cancel()
 	}
@@ -46,7 +46,7 @@ func Create(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := auth.Authorize(atk, rsc.AccessAdmin); err != nil {
+	if err := auth.Authorize(sctx, atk, rsc.AccessAdmin); err != nil {
 		e.Append(cons.ErrorAuth, err.Error())
 		cancel()
 	}

--- a/core/internal/app/flag/flag_service.go
+++ b/core/internal/app/flag/flag_service.go
@@ -23,7 +23,7 @@ func List(
 	defer cancel()
 
 	// authorize operation
-	if err := auth.Authorize(atk, rsc.AccessService); err != nil {
+	if err := auth.Authorize(sctx, atk, rsc.AccessService); err != nil {
 		e.Append(cons.ErrorAuth, err.Error())
 		cancel()
 	}
@@ -48,7 +48,7 @@ func Create(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := auth.Authorize(atk, rsc.AccessUser); err != nil {
+	if err := auth.Authorize(sctx, atk, rsc.AccessUser); err != nil {
 		e.Append(cons.ErrorAuth, err.Error())
 		cancel()
 	}

--- a/core/internal/app/identity/identity_service.go
+++ b/core/internal/app/identity/identity_service.go
@@ -22,7 +22,7 @@ func List(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := auth.Authorize(atk, rsc.AccessService); err != nil {
+	if err := auth.Authorize(sctx, atk, rsc.AccessService); err != nil {
 		e.Append(cons.ErrorAuth, err.Error())
 		cancel()
 	}
@@ -47,7 +47,7 @@ func Create(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := auth.Authorize(atk, rsc.AccessAdmin); err != nil {
+	if err := auth.Authorize(sctx, atk, rsc.AccessAdmin); err != nil {
 		e.Append(cons.ErrorAuth, err.Error())
 		cancel()
 	}

--- a/core/internal/app/project/project_service.go
+++ b/core/internal/app/project/project_service.go
@@ -21,7 +21,7 @@ func List(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := auth.Authorize(atk, rsc.AccessService); err != nil {
+	if err := auth.Authorize(sctx, atk, rsc.AccessService); err != nil {
 		e.Append(cons.ErrorAuth, err.Error())
 		cancel()
 	}
@@ -46,7 +46,7 @@ func Create(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := auth.Authorize(atk, rsc.AccessAdmin); err != nil {
+	if err := auth.Authorize(sctx, atk, rsc.AccessAdmin); err != nil {
 		e.Append(cons.ErrorAuth, err.Error())
 		cancel()
 	}

--- a/core/internal/app/sdkkey/sdkkey_service.go
+++ b/core/internal/app/sdkkey/sdkkey_service.go
@@ -22,7 +22,7 @@ func List(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := auth.Authorize(atk, rsc.AccessUser); err != nil {
+	if err := auth.Authorize(sctx, atk, rsc.AccessUser); err != nil {
 		e.Append(cons.ErrorAuth, err.Error())
 		cancel()
 	}
@@ -47,7 +47,7 @@ func Create(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := auth.Authorize(atk, rsc.AccessAdmin); err != nil {
+	if err := auth.Authorize(sctx, atk, rsc.AccessAdmin); err != nil {
 		e.Append(cons.ErrorAuth, err.Error())
 		cancel()
 	}
@@ -175,4 +175,34 @@ func Delete(
 	}
 
 	return &e
+}
+
+// -------- Custom Service Methods -------- //
+
+// GetRootArgsFromSDKKey get root args from sdk key
+func GetRootArgsFromSDKKey(
+	sctx *srv.Ctx,
+	clientKey string,
+) (*RootArgs, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	return getRootArgsFromSDKKeyResource(
+		ctx,
+		sctx,
+		clientKey,
+	)
+}
+
+// GetRootArgsFromSDKKey get root args from server key
+func GetRootArgsFromServerKey(
+	sctx *srv.Ctx,
+	serverKey string,
+) (*RootArgs, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	return getRootArgsFromServerKeyResource(
+		ctx,
+		sctx,
+		serverKey,
+	)
 }

--- a/core/internal/app/segment/segment_service.go
+++ b/core/internal/app/segment/segment_service.go
@@ -22,7 +22,7 @@ func List(
 	defer cancel()
 
 	// authorize operation
-	if err := auth.Authorize(atk, rsc.AccessService); err != nil {
+	if err := auth.Authorize(sctx, atk, rsc.AccessService); err != nil {
 		e.Append(cons.ErrorAuth, err.Error())
 		cancel()
 	}
@@ -48,7 +48,7 @@ func Create(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := auth.Authorize(atk, rsc.AccessUser); err != nil {
+	if err := auth.Authorize(sctx, atk, rsc.AccessUser); err != nil {
 		e.Append(cons.ErrorAuth, err.Error())
 		cancel()
 	}

--- a/core/internal/app/segmentrule/segmentrule_service.go
+++ b/core/internal/app/segmentrule/segmentrule_service.go
@@ -22,7 +22,7 @@ func List(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := auth.Authorize(atk, rsc.AccessService); err != nil {
+	if err := auth.Authorize(sctx, atk, rsc.AccessService); err != nil {
 		e.Append(cons.ErrorAuth, err.Error())
 		cancel()
 	}
@@ -47,7 +47,7 @@ func Create(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := auth.Authorize(atk, rsc.AccessUser); err != nil {
+	if err := auth.Authorize(sctx, atk, rsc.AccessUser); err != nil {
 		e.Append(cons.ErrorAuth, err.Error())
 		cancel()
 	}

--- a/core/internal/app/targeting/targeting_service.go
+++ b/core/internal/app/targeting/targeting_service.go
@@ -23,7 +23,7 @@ func Create(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := auth.Authorize(atk, rsc.AccessUser); err != nil {
+	if err := auth.Authorize(sctx, atk, rsc.AccessUser); err != nil {
 		e.Append(cons.ErrorAuth, err.Error())
 		cancel()
 	}

--- a/core/internal/app/targetingrule/targetingrule_service.go
+++ b/core/internal/app/targetingrule/targetingrule_service.go
@@ -22,7 +22,7 @@ func List(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := auth.Authorize(atk, rsc.AccessService); err != nil {
+	if err := auth.Authorize(sctx, atk, rsc.AccessService); err != nil {
 		e.Append(cons.ErrorAuth, err.Error())
 		cancel()
 	}
@@ -48,7 +48,7 @@ func Create(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := auth.Authorize(atk, rsc.AccessUser); err != nil {
+	if err := auth.Authorize(sctx, atk, rsc.AccessUser); err != nil {
 		e.Append(cons.ErrorAuth, err.Error())
 		cancel()
 	}

--- a/core/internal/app/trait/trait_service.go
+++ b/core/internal/app/trait/trait_service.go
@@ -21,7 +21,7 @@ func List(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := auth.Authorize(atk, rsc.AccessService); err != nil {
+	if err := auth.Authorize(sctx, atk, rsc.AccessService); err != nil {
 		e.Append(cons.ErrorAuth, err.Error())
 		cancel()
 	}
@@ -46,7 +46,7 @@ func Create(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := auth.Authorize(atk, rsc.AccessAdmin); err != nil {
+	if err := auth.Authorize(sctx, atk, rsc.AccessAdmin); err != nil {
 		e.Append(cons.ErrorAuth, err.Error())
 		cancel()
 	}

--- a/core/internal/app/variation/variation_service.go
+++ b/core/internal/app/variation/variation_service.go
@@ -21,7 +21,7 @@ func List(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := auth.Authorize(atk, rsc.AccessService); err != nil {
+	if err := auth.Authorize(sctx, atk, rsc.AccessService); err != nil {
 		e.Append(cons.ErrorAuth, err.Error())
 		cancel()
 	}
@@ -47,7 +47,7 @@ func Create(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := auth.Authorize(atk, rsc.AccessUser); err != nil {
+	if err := auth.Authorize(sctx, atk, rsc.AccessUser); err != nil {
 		e.Append(cons.ErrorAuth, err.Error())
 		cancel()
 	}

--- a/core/internal/app/workspace/workspace_service.go
+++ b/core/internal/app/workspace/workspace_service.go
@@ -21,7 +21,7 @@ func List(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := auth.Authorize(atk, rsc.AccessRoot); err != nil {
+	if err := auth.Authorize(sctx, atk, rsc.AccessRoot); err != nil {
 		e.Append(cons.ErrorAuth, err.Error())
 		cancel()
 	}
@@ -46,7 +46,7 @@ func Create(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := auth.Authorize(atk, rsc.AccessRoot); err != nil {
+	if err := auth.Authorize(sctx, atk, rsc.AccessRoot); err != nil {
 		e.Append(cons.ErrorAuth, err.Error())
 		cancel()
 	}

--- a/core/internal/pkg/httputil/token.go
+++ b/core/internal/pkg/httputil/token.go
@@ -2,6 +2,7 @@ package httputil
 
 import (
 	rsc "core/internal/pkg/resource"
+	srv "core/internal/pkg/server"
 	"errors"
 	"strings"
 
@@ -23,4 +24,9 @@ func ExtractATK(ctx *gin.Context) (rsc.Token, error) {
 	atk := rsc.Token(stk[1])
 
 	return atk, nil
+}
+
+// SecureOverideATK get security token to overide protected operations
+func SecureOverideATK(sctx *srv.Ctx) rsc.Token {
+	return rsc.Token(sctx.SecureRuntimeHash)
 }

--- a/core/internal/pkg/polling/polling.go
+++ b/core/internal/pkg/polling/polling.go
@@ -1,10 +1,30 @@
 package polling
 
-import rsc "core/internal/pkg/resource"
+import (
+	"context"
+	rsc "core/internal/pkg/resource"
+	srv "core/internal/pkg/server"
+	"core/pkg/evaluator"
+)
+
+// RootHeaders arguments for selecting root resource
+type RootHeaders struct {
+	SDKKey string
+}
 
 // RootArgs arguments for selecting root resource
 type RootArgs struct {
 	WorkspaceKey   rsc.Key
 	ProjectKey     rsc.Key
 	EnvironmentKey rsc.Key
+}
+
+// CachedServiceArgs args used for cached services
+type CachedServiceArgs struct {
+	Sctx        *srv.Ctx
+	Ctx         context.Context
+	Atk         rsc.Token
+	Ectx        evaluator.Context
+	RootHeaders RootHeaders
+	CacheKey    string
 }

--- a/core/internal/pkg/polling/polling_service.go
+++ b/core/internal/pkg/polling/polling_service.go
@@ -15,7 +15,7 @@ func Get(
 	sctx *srv.Ctx,
 	atk rsc.Token,
 	etag string,
-	a RootArgs,
+	a RootHeaders,
 ) (*res.Success, string, *res.Errors) {
 	var e res.Errors
 	var o *res.Success
@@ -24,19 +24,17 @@ func Get(
 	retag := etag
 	cacheKey := hashutil.HashKeys(
 		"polling-get-raw-ruleset",
-		string(a.WorkspaceKey),
-		string(a.ProjectKey),
-		string(a.EnvironmentKey),
+		a.SDKKey,
 	)
 	otag, _ := sctx.Cache.Get(ctx, cacheKey).Result()
 
 	if etag == "" || etag != otag {
-		r, _e, newETag := getAndSetCache(GetAndSetCacheArgs{
-			Sctx:     sctx,
-			Atk:      atk,
-			Ctx:      ctx,
-			RootArgs: a,
-			CacheKey: cacheKey,
+		r, _e, newETag := getAndSetCache(CachedServiceArgs{
+			Sctx:        sctx,
+			Ctx:         ctx,
+			Atk:         atk,
+			RootHeaders: a,
+			CacheKey:    cacheKey,
 		})
 		if !_e.IsEmpty() {
 			e.Extend(&_e)
@@ -44,12 +42,12 @@ func Get(
 		o = &r
 		retag = newETag
 	} else {
-		go getAndSetCache(GetAndSetCacheArgs{
-			Sctx:     sctx,
-			Atk:      atk,
-			Ctx:      ctx,
-			RootArgs: a,
-			CacheKey: cacheKey,
+		go getAndSetCache(CachedServiceArgs{
+			Sctx:        sctx,
+			Ctx:         ctx,
+			Atk:         atk,
+			RootHeaders: a,
+			CacheKey:    cacheKey,
 		})
 	}
 
@@ -63,7 +61,7 @@ func Evaluate(
 	atk rsc.Token,
 	etag string,
 	ectx evaluator.Context,
-	a RootArgs,
+	a RootHeaders,
 ) (*res.Success, string, *res.Errors) {
 	var e res.Errors
 	var o *res.Success
@@ -72,20 +70,18 @@ func Evaluate(
 	retag := etag
 	cacheKey := hashutil.HashKeys(
 		"polling-get-evaluated-ruleset",
-		string(a.WorkspaceKey),
-		string(a.ProjectKey),
-		string(a.EnvironmentKey),
+		a.SDKKey,
 	)
 	otag, _ := sctx.Cache.Get(ctx, cacheKey).Result()
 
 	if etag == "" || etag != otag {
-		r, _e, newETag := evaluateAndSetCache(EvaluateAndSetCacheArgs{
-			Sctx:     sctx,
-			Atk:      atk,
-			Ctx:      ctx,
-			Ectx:     ectx,
-			RootArgs: a,
-			CacheKey: cacheKey,
+		r, _e, newETag := evaluateAndSetCache(CachedServiceArgs{
+			Sctx:        sctx,
+			Ctx:         ctx,
+			Atk:         atk,
+			Ectx:        ectx,
+			RootHeaders: a,
+			CacheKey:    cacheKey,
 		})
 		if !_e.IsEmpty() {
 			e.Extend(&_e)
@@ -93,13 +89,13 @@ func Evaluate(
 		o = &r
 		retag = newETag
 	} else {
-		go evaluateAndSetCache(EvaluateAndSetCacheArgs{
-			Sctx:     sctx,
-			Atk:      atk,
-			Ctx:      ctx,
-			Ectx:     ectx,
-			RootArgs: a,
-			CacheKey: cacheKey,
+		go evaluateAndSetCache(CachedServiceArgs{
+			Sctx:        sctx,
+			Ctx:         ctx,
+			Atk:         atk,
+			Ectx:        ectx,
+			RootHeaders: a,
+			CacheKey:    cacheKey,
 		})
 	}
 

--- a/core/internal/pkg/server/server.go
+++ b/core/internal/pkg/server/server.go
@@ -10,9 +10,10 @@ import (
 
 // Ctx primary app context structure
 type Ctx struct {
-	Cache  *redis.Client
-	DB     *pgxpool.Pool
-	Log    *logger.Logger
-	Policy *policy.Policy
-	Metric string // TODO: add metric interface
+	Cache             *redis.Client
+	DB                *pgxpool.Pool
+	Log               *logger.Logger
+	Policy            *policy.Policy
+	Metric            string // TODO: add metric interface
+	SecureRuntimeHash string
 }

--- a/core/internal/pkg/server/server_setup.go
+++ b/core/internal/pkg/server/server_setup.go
@@ -8,6 +8,8 @@ import (
 	"core/pkg/cache"
 	"core/pkg/db"
 	"core/pkg/logger"
+
+	"github.com/google/uuid"
 )
 
 // Config app context configuration
@@ -22,6 +24,9 @@ type Config struct {
 
 // Setup init services that make up app-context
 func Setup(cfg Config) (*Ctx, error) {
+	// setup: secure runtime hash
+	secureRuntimeHash := uuid.New().String()
+
 	// setup: logger
 	logInst := logger.New(logger.Config{
 		Verbose: cfg.Verbose,
@@ -57,9 +62,10 @@ func Setup(cfg Config) (*Ctx, error) {
 	}
 
 	return &Ctx{
-		Cache:  cacheInst,
-		DB:     dbInst,
-		Log:    logInst,
-		Policy: policyInst,
+		Cache:             cacheInst,
+		DB:                dbInst,
+		Log:               logInst,
+		Policy:            policyInst,
+		SecureRuntimeHash: secureRuntimeHash,
 	}, nil
 }

--- a/core/migrations/000015_init_sdk_key.up.sql
+++ b/core/migrations/000015_init_sdk_key.up.sql
@@ -14,7 +14,8 @@ CREATE TABLE sdk_key (
   -- references
   environment_id resource_id REFERENCES environment (id),
   -- contraints
-  CONSTRAINT sdk_client_server_key UNIQUE(client_key, server_key, environment_id)
+  CONSTRAINT sdk_server_key UNIQUE(server_key, environment_id),
+  CONSTRAINT sdk_client_key UNIQUE(client_key, environment_id)
 );
 
 END;

--- a/core/pkg/evaluator/evaluator.go
+++ b/core/pkg/evaluator/evaluator.go
@@ -2,7 +2,7 @@ package evaluator
 
 // Context evaluation context is essentially the data required to evaluate a flag
 type Context struct {
-	Identifier string                 `json:"key"`
+	Identifier string                 `json:"identifier"`
 	Traits     map[string]interface{} `json:"traits,omitempty"`
 }
 


### PR DESCRIPTION
## Context

SDK keys provide faster resource lookups rather than joining on workspace/project/environment keys.

```sh
curl --request POST \
  --url http://127.0.0.1:9051/polling \
  --header 'Content-Type: application/json' \
  --header 'x-sdk-key: sdk-client_fbb5464-0a71-4fb0-9268-b426d6b710e5' \
  --data '{
	"identifier": "some-user-key",
	"traits": {
		"some-trait-key": "aaaa"
	}
}'
```

## Changes

This PR introduces the following changes:
* Updated polling service to use SDK key in header.

## Tasks

I've completed the following tasks:
- [x] Signed the Contributers License Agreement (CLA)
- [ ] Added/updated tests
- [ ] Added/updated docs
