### PR TITLE
OSS-106: add fk constraint to cascade on delete / update 

### DIFF
--- a/core/migrations/000003_init_project.up.sql
+++ b/core/migrations/000003_init_project.up.sql
@@ -9,7 +9,7 @@ CREATE TABLE project (
   description resource_description,
   tags resource_tags,
   -- references
-  workspace_id resource_id REFERENCES workspace (id),
+  workspace_id resource_id REFERENCES workspace (id) ON DELETE CASCADE ON UPDATE CASCADE,
   -- contraints
   CONSTRAINT project_key UNIQUE(key, workspace_id)
 );

--- a/core/migrations/000004_init_environment.up.sql
+++ b/core/migrations/000004_init_environment.up.sql
@@ -9,7 +9,7 @@ CREATE TABLE environment (
   description resource_description,
   tags resource_tags,
   -- references
-  project_id resource_id REFERENCES project (id),
+  project_id resource_id REFERENCES project (id) ON DELETE CASCADE ON UPDATE CASCADE,
   -- contraints
   CONSTRAINT environment_key UNIQUE(key, project_id)
 );

--- a/core/migrations/000006_init_flag.up.sql
+++ b/core/migrations/000006_init_flag.up.sql
@@ -9,7 +9,7 @@ CREATE TABLE flag (
   description resource_description,
   tags resource_tags,
   -- references
-  project_id resource_id REFERENCES project (id),
+  project_id resource_id REFERENCES project (id) ON DELETE CASCADE ON UPDATE CASCADE,
   -- contraints
   CONSTRAINT flag_key UNIQUE(key, project_id)
 );

--- a/core/migrations/000007_init_variation.up.sql
+++ b/core/migrations/000007_init_variation.up.sql
@@ -9,7 +9,7 @@ CREATE TABLE variation (
   description resource_description,
   tags resource_tags,
   -- references
-  flag_id resource_id REFERENCES flag (id),
+  flag_id resource_id REFERENCES flag (id) ON DELETE CASCADE ON UPDATE CASCADE,
   -- contraints
   CONSTRAINT variation_key UNIQUE(key, flag_id)
 );

--- a/core/migrations/000008_init_segment.up.sql
+++ b/core/migrations/000008_init_segment.up.sql
@@ -9,7 +9,7 @@ CREATE TABLE segment (
   description resource_description,
   tags resource_tags,
   -- references
-  project_id resource_id REFERENCES project (id),
+  project_id resource_id REFERENCES project (id) ON DELETE CASCADE ON UPDATE CASCADE,
   -- contraints
   CONSTRAINT segment_key UNIQUE(key, project_id)
 );

--- a/core/migrations/000009_init_segment_rule.up.sql
+++ b/core/migrations/000009_init_segment_rule.up.sql
@@ -13,8 +13,8 @@ CREATE TABLE segment_rule (
   description resource_description,
   tags resource_tags,
   -- references
-  segment_id resource_id REFERENCES segment (id),
-  environment_id resource_id REFERENCES environment (id),
+  segment_id resource_id REFERENCES segment (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  environment_id resource_id REFERENCES environment (id) ON DELETE CASCADE ON UPDATE CASCADE,
   -- contraints
   CONSTRAINT segment_rule_key UNIQUE(key, segment_id, environment_id)
 );

--- a/core/migrations/000010_init_identity.up.sql
+++ b/core/migrations/000010_init_identity.up.sql
@@ -8,7 +8,7 @@ CREATE TABLE identity (
   -- attributes
   key identity_resource_key,
   -- references
-  environment_id resource_id REFERENCES environment (id),
+  environment_id resource_id REFERENCES environment (id) ON DELETE CASCADE ON UPDATE CASCADE,
   -- contraints
   CONSTRAINT identity_key UNIQUE(key, environment_id)
 );

--- a/core/migrations/000011_init_trait.up.sql
+++ b/core/migrations/000011_init_trait.up.sql
@@ -10,7 +10,7 @@ CREATE TABLE trait (
   key trait_resource_key,
   is_identifier BOOLEAN DEFAULT FALSE,
   -- references
-  environment_id resource_id REFERENCES environment (id),
+  environment_id resource_id REFERENCES environment (id) ON DELETE CASCADE ON UPDATE CASCADE,
   -- contraints
   CONSTRAINT trait_key UNIQUE(key, environment_id)
 );

--- a/core/migrations/000012_init_targeting.up.sql
+++ b/core/migrations/000012_init_targeting.up.sql
@@ -14,8 +14,8 @@ CREATE TABLE targeting (
   -- attributes
   enabled BOOLEAN DEFAULT FALSE NOT NULL,
   -- references
-  flag_id UUID REFERENCES flag (id),
-  environment_id UUID REFERENCES environment (id),
+  flag_id UUID REFERENCES flag (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  environment_id UUID REFERENCES environment (id) ON DELETE CASCADE ON UPDATE CASCADE,
   -- contraints
   CONSTRAINT uq_flag_environment UNIQUE(flag_id, environment_id)
 );
@@ -25,8 +25,8 @@ CREATE TABLE targeting_fallthrough_variation (
   -- attributes
   weight INT DEFAULT 100  NOT NULL,
   -- references
-  variation_id UUID REFERENCES variation (id) NOT NULL,
-  targeting_id UUID REFERENCES targeting (id) NOT NULL,
+  variation_id UUID REFERENCES variation (id) ON DELETE CASCADE ON UPDATE CASCADE NOT NULL,
+  targeting_id UUID REFERENCES targeting (id) ON DELETE CASCADE ON UPDATE CASCADE NOT NULL,
   -- constraints
   CHECK (weight BETWEEN 0 AND 100)
 );

--- a/core/migrations/000013_init_targeting_rule.up.sql
+++ b/core/migrations/000013_init_targeting_rule.up.sql
@@ -29,9 +29,9 @@ CREATE TABLE targeting_rule (
   description resource_description,
   tags resource_tags,
   -- references
-  identity_id UUID REFERENCES identity (id),
-  segment_id UUID REFERENCES segment (id),
-  targeting_id UUID REFERENCES targeting (id) NOT NULL,
+  identity_id UUID REFERENCES identity (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  segment_id UUID REFERENCES segment (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  targeting_id UUID REFERENCES targeting (id) ON DELETE CASCADE ON UPDATE CASCADE NOT NULL,
   -- contraints
   CONSTRAINT targeting_rule_key UNIQUE(key, targeting_id)
 );
@@ -42,8 +42,8 @@ CREATE TABLE targeting_rule_variation (
   -- attributes
   weight INT DEFAULT 100 NOT NULL,
   -- references
-  variation_id UUID REFERENCES variation (id) NOT NULL,
-  targeting_rule_id UUID REFERENCES targeting_rule (id) NOT NULL,
+  variation_id UUID REFERENCES variation (id) ON DELETE CASCADE ON UPDATE CASCADE NOT NULL,
+  targeting_rule_id UUID REFERENCES targeting_rule (id) ON DELETE CASCADE ON UPDATE CASCADE NOT NULL,
   -- constraints
   CHECK (weight BETWEEN 0 AND 100)
 );

--- a/core/migrations/000014_init_evaluation.up.sql
+++ b/core/migrations/000014_init_evaluation.up.sql
@@ -3,9 +3,9 @@ BEGIN;
 CREATE TABLE evaluation (
   time BIGINT DEFAULT EXTRACT(EPOCH FROM NOW()) PRIMARY KEY,
   -- references
-  variation_id resource_id REFERENCES variation (id),
-  targeting_id resource_id REFERENCES targeting (id),
-  identity_id resource_id REFERENCES identity (id)
+  variation_id resource_id REFERENCES variation (id) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  targeting_id resource_id REFERENCES targeting (id) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  identity_id resource_id REFERENCES identity (id) ON DELETE NO ACTION ON UPDATE NO ACTION
 );
 
 END;

--- a/core/migrations/000015_init_sdk_key.up.sql
+++ b/core/migrations/000015_init_sdk_key.up.sql
@@ -12,10 +12,10 @@ CREATE TABLE sdk_key (
   description resource_description,
   tags resource_tags,
   -- references
-  environment_id resource_id REFERENCES environment (id),
+  environment_id resource_id REFERENCES environment (id) ON DELETE CASCADE ON UPDATE CASCADE NOT NULL,
   -- contraints
-  CONSTRAINT sdk_server_key UNIQUE(server_key, environment_id),
-  CONSTRAINT sdk_client_key UNIQUE(client_key, environment_id)
+  CONSTRAINT sdk_server_key UNIQUE(server_key),
+  CONSTRAINT sdk_client_key UNIQUE(client_key)
 );
 
 END;


### PR DESCRIPTION
## Context

Add foreign key constraint to cascade on delete / update. So when top level resources are removed, child resources automatically get removed. 

## Changes

This PR introduces the following changes:
* Update migrations

## Tasks

I've completed the following tasks:
- [x] Signed the Contributers License Agreement (CLA)
- [ ] Added/updated tests
- [ ] Added/updated docs
