### PR TITLE
FIX: routing and webpack-dev-server after dependabot updates

### DIFF
--- a/ui/app/lib/entity-store/entity-context.tsx
+++ b/ui/app/lib/entity-store/entity-context.tsx
@@ -1,5 +1,4 @@
 import React, { createContext, useState } from 'react';
-import useLocalStorage from '@rehooks/local-storage';
 
 import { createStore, EntityStore } from './entity-store';
 import { createActions, EntityActions } from './entity-actions';
@@ -25,9 +24,11 @@ function createEntityContext<Entity> (
   >(_intialState);
 
   const Provider: React.FC = ({ children }) => {
-    const [state, setState] = opts?.useLocalStorage
-      ? useLocalStorage<EntityStore<Entity>>(entityKey, _intialState)
-      : useState<EntityStore<Entity>>(_intialState);
+    const [state, setState] = useState<EntityStore<Entity>>(_intialState);
+    // TODO: use @rehooks/local-storage to persist state to localstorage.
+    // opts?.useLocalStorage
+    // ? useLocalStorage<EntityStore<Entity>>(entityKey, _intialState)
+    // : useState<EntityStore<Entity>>(_intialState);
 
     const actions = createActions<Entity>(state, setState);
     return (

--- a/ui/app/router/router.tsx
+++ b/ui/app/router/router.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter, Switch, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
 import { RouteParams } from './router.types';
 import Context from '../context';
@@ -25,38 +25,38 @@ const {
 const Router: React.FC = () => (
   <Context>
     <BrowserRouter>
-      <Switch>
+      <Routes>
         {/* Instances */}
-        <Route path="/" component={Instances} />
-        <Route path="/instances" component={Instances} />
+        <Route path="/" element={<Instances />} />
+        <Route path="/instances" element={<Instances />} />
         {/* Workspaces */}
-        <Route path={`/workspaces/${InstanceKey}`} component={Workspaces} />
+        <Route path={`/workspaces/${InstanceKey}`} element={<Workspaces />} />
         {/* Projects */}
         <Route
           path={`/projects/${InstanceKey}/${WorkspaceKey}`}
-          component={Projects}
+          element={<Projects />}
         />
         {/* Flags */}
         <Route
           path={`/flags/${InstanceKey}/${WorkspaceKey}/${ProjectKey}/${EnvironmentKey}`}
-          component={Flags}
+          element={<Flags />}
         />
         {/* Segments */}
         <Route
           path={`/segments/${InstanceKey}/${WorkspaceKey}/${ProjectKey}/${EnvironmentKey}`}
-          component={Segments}
+          element={<Segments />}
         />
         {/* Identities */}
         <Route
           path={`/identities/${InstanceKey}/${WorkspaceKey}/${ProjectKey}/${EnvironmentKey}`}
-          component={Identities}
+          element={<Identities />}
         />
         {/* Traits */}
         <Route
           path={`/traits/${InstanceKey}/${WorkspaceKey}/${ProjectKey}/${EnvironmentKey}`}
-          component={Traits}
+          element={<Traits />}
         />
-      </Switch>
+      </Routes>
     </BrowserRouter>
   </Context>
 );

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -14,5 +14,6 @@
     "outDir": "./dist",
     "strict": true ,
     "esModuleInterop": true,
+    "types": ["node"]
   }
 }

--- a/ui/webpack/react.webpack.js
+++ b/ui/webpack/react.webpack.js
@@ -9,7 +9,7 @@ module.exports = {
     mainFields: ['main', 'module', 'browser']
   },
   entry: path.resolve(rootPath, 'app', 'index.tsx'),
-  target: 'electron-renderer',
+  target: 'web',
   devtool: 'source-map',
   module: {
     rules: [
@@ -27,13 +27,16 @@ module.exports = {
     ]
   },
   devServer: {
-    contentBase: path.join(rootPath, 'dist/renderer'),
+    static: {
+      directory: path.join(rootPath, 'dist/renderer')
+    },
     historyApiFallback: true,
     compress: true,
     hot: true,
-    host: '0.0.0.0',
     port: 4000,
-    publicPath: '/'
+    devMiddleware: {
+      writeToDisk: true
+    },
   },
   output: {
     path: path.resolve(rootPath, 'dist/renderer'),


### PR DESCRIPTION
## Context

The webpack dev server and routing broke after dependabot updates. For some reason dependabot merged in breaking changes....

## Changes

This PR introduces the following changes:
* Change 1
* ...

## Tasks

I've completed the following tasks:
- [x] Signed the Contributers License Agreement (CLA)
- [ ] Added/updated tests
- [ ] Added/updated docs
