### PR TITLE
Default to flags when env variables are not set

### DIFF
--- a/core/cmd/manage/manage_access.go
+++ b/core/cmd/manage/manage_access.go
@@ -67,9 +67,9 @@ var ManageAccessCreateCommand cli.Command = cli.Command{
 		senv, err := srv.Setup(srv.Config{
 			Ctx:           context.Background(),
 			PGConnStr:     ctx.String(cmdutil.PGConnStrFlag),
-			RedisAddr:     ctx.String(cmdutil.RedisAddr),
-			RedisPassword: ctx.String(cmdutil.RedisPassword),
-			RedisDB:       int(ctx.Uint(cmdutil.RedisDB)),
+			RedisAddr:     ctx.String(cmdutil.RedisAddrFlag),
+			RedisPassword: ctx.String(cmdutil.RedisPasswordFlag),
+			RedisDB:       int(ctx.Uint(cmdutil.RedisDBFlag)),
 			Verbose:       ctx.Bool(cmdutil.VerboseFlag),
 		})
 		if err != nil {

--- a/core/cmd/worker/worker_api.go
+++ b/core/cmd/worker/worker_api.go
@@ -28,9 +28,9 @@ func StartAPI(ctx *cli.Context, senv *srvenv.Env, wg *sync.WaitGroup) {
 		Host:          ctx.String(HostFlag),
 		APIPort:       ctx.Int(APIPortFlag),
 		PGConnStr:     ctx.String(cmdutil.PGConnStrFlag),
-		RedisAddr:     ctx.String(cmdutil.RedisAddr),
-		RedisPassword: ctx.String(cmdutil.RedisPassword),
-		RedisDB:       int(ctx.Uint(cmdutil.RedisDB)),
+		RedisAddr:     ctx.String(cmdutil.RedisAddrFlag),
+		RedisPassword: ctx.String(cmdutil.RedisPasswordFlag),
+		RedisDB:       int(ctx.Uint(cmdutil.RedisDBFlag)),
 		Verbose:       ctx.Bool(cmdutil.VerboseFlag),
 	}
 

--- a/core/cmd/worker/worker_setup.go
+++ b/core/cmd/worker/worker_setup.go
@@ -17,9 +17,9 @@ func Setup(ctx *cli.Context, wg *sync.WaitGroup) *srvenv.Env {
 	senv, err := srv.Setup(srv.Config{
 		Ctx:           context.Background(),
 		PGConnStr:     ctx.String(cmdutil.PGConnStrFlag),
-		RedisAddr:     ctx.String(cmdutil.RedisAddr),
-		RedisPassword: ctx.String(cmdutil.RedisPassword),
-		RedisDB:       int(ctx.Uint(cmdutil.RedisDB)),
+		RedisAddr:     ctx.String(cmdutil.RedisAddrFlag),
+		RedisPassword: ctx.String(cmdutil.RedisPasswordFlag),
+		RedisDB:       int(ctx.Uint(cmdutil.RedisDBFlag)),
 		Verbose:       ctx.Bool(cmdutil.VerboseFlag),
 	})
 	if err != nil {

--- a/core/internal/pkg/cmdutil/global_flags.go
+++ b/core/internal/pkg/cmdutil/global_flags.go
@@ -2,6 +2,8 @@ package cmdutil
 
 import (
 	cons "core/internal/pkg/constants"
+	"core/internal/pkg/osenv"
+	"strconv"
 
 	"github.com/urfave/cli/v2"
 )
@@ -10,11 +12,11 @@ const (
 	// PGConnStrFlag Postgres URL Flag
 	PGConnStrFlag = "pg-url"
 	// RedisAddr Redis address (host:port)
-	RedisAddr = "redis-addr"
+	RedisAddrFlag = "redis-addr"
 	// RedisPassword Redis password
-	RedisPassword = "redis-pw"
+	RedisPasswordFlag = "redis-pw"
 	// RedisDB Redis DB number
-	RedisDB = "redis-db"
+	RedisDBFlag = "redis-db"
 	// VerboseFlag Verbose flag (show debug logging)
 	VerboseFlag = "verbose"
 )
@@ -24,22 +26,28 @@ var GlobalFlags []cli.Flag = []cli.Flag{
 	&cli.StringFlag{
 		Name:  PGConnStrFlag,
 		Usage: "Postgres Connection URL",
-		Value: cons.DefaultPGConnStr,
+		Value: osenv.GetEnvOrDefault(osenv.PGConnStrEnv, cons.DefaultPGConnStr),
 	},
 	&cli.StringFlag{
-		Name:  RedisAddr,
+		Name:  RedisAddrFlag,
 		Usage: "Redis address (host:port)",
-		Value: cons.DefaultRedisAddr,
+		Value: osenv.GetEnvOrDefault(osenv.RedisAddrEnv, cons.DefaultRedisAddr),
 	},
 	&cli.StringFlag{
-		Name:  RedisPassword,
+		Name:  RedisPasswordFlag,
 		Usage: "Redis password",
-		Value: cons.DefaultRedisPassword,
+		Value: osenv.GetEnvOrDefault(osenv.RedisPasswordEnv, cons.DefaultRedisPassword),
 	},
 	&cli.UintFlag{
-		Name:  RedisDB,
+		Name:  RedisDBFlag,
 		Usage: "Redis database (default: 0)",
-		Value: uint(cons.DefaultRedisDB),
+		Value: func() uint {
+			val, err := strconv.ParseUint(osenv.GetEnvOrDefault(osenv.RedisDBEnv, strconv.FormatUint(uint64(cons.DefaultRedisDB), 10)), 10, 0)
+			if err != nil {
+				panic(err)
+			}
+			return uint(val)
+		}(),
 	},
 	&cli.BoolFlag{
 		Name:    VerboseFlag,

--- a/core/internal/pkg/constants/defaults.go
+++ b/core/internal/pkg/constants/defaults.go
@@ -14,7 +14,7 @@ var (
 	// DefaultRedisPassword default redis password
 	DefaultRedisPassword string = ""
 	// DefaultRedisDB default redis database number
-	DefaultRedisDB int = 0
+	DefaultRedisDB uint = 0
 	// DefaultAPIPort default HTTP API server port
 	DefaultAPIPort int = 5051
 	// DefaultStreamerPort default streamer server port

--- a/core/internal/pkg/osenv/osenv.go
+++ b/core/internal/pkg/osenv/osenv.go
@@ -1,0 +1,23 @@
+package osenv
+
+import (
+	"os"
+)
+
+const (
+	// PGConnStrEnv Postgres URL environment variable
+	PGConnStrEnv = "FLAGBASE_CORE_PG_URL"
+	// RedisAddr Redis address (host:port) environment variable
+	RedisAddrEnv = "FLAGBASE_CORE_REDIR_ADDR"
+	// RedisPassword Redis password environment variable
+	RedisPasswordEnv = "FLAGBASE_CORE_REDIS_PASSWORD"
+	// RedisDB Redis DB number environment variable
+	RedisDBEnv = "FLAGBASE_CORE_REDIS_DB"
+)
+
+func GetEnvOrDefault(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}


### PR DESCRIPTION
## Context

Read from env variables when flags are not set.

## Changes

This PR introduces the following changes:
* Added the following env variables: `FLAGBASE_CORE_PG_URL`, `FLAGBASE_CORE_REDIR_ADDR`, `FLAGBASE_CORE_REDIS_PASSWORD`, `FLAGBASE_CORE_REDIS_DB` 

## Tasks

I've completed the following tasks:
- [x] Signed the Contributers License Agreement (CLA)
- [ ] Added/updated tests
- [ ] Added/updated docs
