### PR TITLE
cjoy: fix docker version for docusaurus

### DIFF
--- a/www/Dockerfile
+++ b/www/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.13.0
+FROM node:16.14
 LABEL maintainer="Flagbase Team <hello@flagbase.com>"
 
 RUN npx create-docusaurus@2.0.0-beta.9 docusaurus classic --typescript


### PR DESCRIPTION
## Context

Redoc doesn't like node 16.3 for some reason...

## Changes

This PR introduces the following changes:
* Change 1
* ...

## Tasks

I've completed the following tasks:
- [x] Signed the Contributers License Agreement (CLA)
- [ ] Added/updated tests
- [ ] Added/updated docs
