### PR TITLE
cjoy: /healthcheck endpoint to return more info

### DIFF
--- a/core/internal/app/healthcheck/model/healthcheck_model.go
+++ b/core/internal/app/healthcheck/model/healthcheck_model.go
@@ -1,0 +1,14 @@
+package healthcheck
+
+// HealthStatus represents the state of the system health
+type HealthStatus struct {
+	ID        string        `json:"id" jsonapi:"primary,health_status"`
+	Resources ResourceState `json:"resources" jsonapi:"attr,resources"`
+	Status    string        `json:"status" jsonapi:"attr,status"`
+}
+
+// ResourceState represents the state of the resources
+type ResourceState struct {
+	DB    string `json:"db" jsonapi:"attr,db"`
+	Cache string `json:"cache" jsonapi:"attr,cache"`
+}

--- a/core/internal/app/healthcheck/service/healthcheck_service.go
+++ b/core/internal/app/healthcheck/service/healthcheck_service.go
@@ -2,7 +2,10 @@ package service
 
 import (
 	"context"
+	healthcheckmodel "core/internal/app/healthcheck/model"
 	"core/internal/pkg/srvenv"
+
+	"github.com/google/uuid"
 )
 
 type Service struct {
@@ -16,13 +19,33 @@ func NewService(senv *srvenv.Env) *Service {
 }
 
 // HealthCheck sends a useless query to the database to see if the connection is working.
-func (s *Service) HealthCheck() (string, error) {
-	var msg string
-	row := s.Senv.DB.QueryRow(context.Background(), "SELECT 'OK'")
-	if err := row.Scan(&msg); err != nil {
+func (s *Service) HealthCheck() *healthcheckmodel.HealthStatus {
+	status := "OK"
+
+	// cache status
+	cacheStatus := "OK"
+	cachePing := s.Senv.Cache.Ping()
+	if err := cachePing.Err(); err != nil {
 		s.Senv.Log.Error().Msg(err.Error())
-		return "error", err
+		cacheStatus = "ERR: " + err.Error()
+		status = "FAIL"
 	}
 
-	return msg, nil
+	// db status
+	var DBStatus string
+	row := s.Senv.DB.QueryRow(context.Background(), "SELECT 'OK'")
+	if err := row.Scan(&DBStatus); err != nil {
+		s.Senv.Log.Error().Msg(err.Error())
+		DBStatus = "ERR: " + err.Error()
+		status = "FAIL"
+	}
+
+	return &healthcheckmodel.HealthStatus{
+		ID:     uuid.New().String(),
+		Status: status,
+		Resources: healthcheckmodel.ResourceState{
+			DB:    DBStatus,
+			Cache: cacheStatus,
+		},
+	}
 }

--- a/core/internal/app/healthcheck/transport/healthcheck_api.go
+++ b/core/internal/app/healthcheck/transport/healthcheck_api.go
@@ -2,8 +2,10 @@ package transport
 
 import (
 	healthcheckservice "core/internal/app/healthcheck/service"
+	res "core/pkg/response"
 	"net/http"
 
+	"core/internal/pkg/httputil"
 	"core/internal/pkg/srvenv"
 
 	"github.com/gin-gonic/gin"
@@ -29,10 +31,15 @@ func ApplyRoutes(senv *srvenv.Env, r *gin.RouterGroup) {
 }
 
 func (h *APIHandler) healthCheckAPIHandler(ctx *gin.Context) {
-	pong, err := h.HealthCheckService.HealthCheck()
-	if err != nil {
-		ctx.AbortWithStatus(http.StatusInternalServerError)
-		return
-	}
-	ctx.Data(http.StatusOK, "text/plain", []byte(pong))
+	r := h.HealthCheckService.HealthCheck()
+
+	httputil.SendJSON(
+		ctx,
+		http.StatusOK,
+		r,
+		http.StatusInternalServerError,
+		res.Errors{
+			Errors: []*res.Error{},
+		},
+	)
 }

--- a/sdk/js-client-sdk/examples/polling-app.stories.tsx
+++ b/sdk/js-client-sdk/examples/polling-app.stories.tsx
@@ -12,7 +12,7 @@ const Template: Story<PollingAppProps> = (args) => <PollingApp {...args} />;
 
 export const DefaultPollingApp = Template.bind({});
 DefaultPollingApp.args = {
-  clientKey: 'sdk-server_5121db29-a7c9-4dde-ba52-4b6fed4247b2',
+  clientKey: 'sdk-client_eb64a3a3-8157-41dc-922a-a7fc8e05b377',
   identity: {
     identifier: "cool-user",
     traits: {


### PR DESCRIPTION
## Context

`/healthcheck` endpoint to return data about db and cache status

<img width="522" alt="image" src="https://user-images.githubusercontent.com/10393925/223402529-e48a0e84-d97e-44fb-8794-57a11cba3463.png">

## Changes

This PR introduces the following changes:
* Add HealthStatus model
* Update healthcheck service
* Update healthcheck endoints

## Tasks

I've completed the following tasks:
- [x] Signed the Contributers License Agreement (CLA)
- [ ] Added/updated tests
- [ ] Added/updated docs
