### PR TITLE
HOTFIX: add patch to cors whitelist

### DIFF
--- a/core/internal/pkg/httpserver/httpserver.go
+++ b/core/internal/pkg/httpserver/httpserver.go
@@ -35,7 +35,7 @@ func New(
 	config.AllowAllOrigins = true
 	config.AllowCredentials = true
 	config.AllowWildcard = true
-	config.AllowMethods = []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"}
+	config.AllowMethods = []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"}
 	config.AllowHeaders = []string{"*"}
 	config.ExposeHeaders = []string{"*"}
 


### PR DESCRIPTION
## Context

PATCH is not included in the CORS allowed methods list.... which explains why it's erroring out.

## Changes

This PR introduces the following changes:
* Change 1
* ...

## Tasks

I've completed the following tasks:
- [x] Signed the Contributers License Agreement (CLA)
- [ ] Added/updated tests
- [ ] Added/updated docs
