### PR TITLE
OSS-124: use correct default environment key from staging sdk

### DIFF
--- a/core/internal/app/project/service/project_service_util.go
+++ b/core/internal/app/project/service/project_service_util.go
@@ -82,7 +82,7 @@ func (s *Service) createChildren(
 		sdkkeymodel.RootArgs{
 			WorkspaceKey:   a.WorkspaceKey,
 			ProjectKey:     i.Key,
-			EnvironmentKey: envProd.Key,
+			EnvironmentKey: envStg.Key,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
## Context

Should use correct default environment key for staging sdk keys. 

## Changes

This PR introduces the following changes:
* Change 1
* ...

## Tasks

I've completed the following tasks:
- [x] Signed the Contributers License Agreement (CLA)
- [ ] Added/updated tests
- [ ] Added/updated docs
